### PR TITLE
Reconfigure Navigation after copy or move. 

### DIFF
--- a/ftw/book/upgrades/configure.zcml
+++ b/ftw/book/upgrades/configure.zcml
@@ -20,15 +20,6 @@
         profile="ftw.book:default"
         />
 
-    <genericsetup:upgradeStep
-        title="Set Book portlets."
-        description=""
-        source="2.2"
-        destination="2200"
-        handler="ftw.book.upgrades.to2200.SetBookPortlest"
-        profile="ftw.book:default"
-        />
-
     <genericsetup:registerProfile
         name="2200"
         title="ftw.book.upgrades.2200"
@@ -36,6 +27,17 @@
         directory="profiles/2200"
         for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
         provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+
+    <!-- 2200 -> 2201 -->
+    <genericsetup:upgradeStep
+        title="Fix broken navigation portlets of moved books."
+        description=""
+        source="2200"
+        destination="2201"
+        handler="ftw.book.upgrades.to2201.SetBookPortlets"
+        profile="ftw.book:default"
         />
 
 </configure>

--- a/ftw/book/upgrades/to2200.py
+++ b/ftw/book/upgrades/to2200.py
@@ -2,10 +2,6 @@ from Acquisition import aq_parent, aq_inner
 from ftw.upgrade import ProgressLogger
 from ftw.upgrade import UpgradeStep
 import logging
-from ftw.book.eventhandler import add_navigation_portlet
-from plone.portlets.interfaces import IPortletAssignmentMapping
-from plone.portlets.interfaces import IPortletManager
-from zope.component import getUtility, getMultiAdapter
 
 
 LOG = logging.getLogger('ftw.book.upgrades')
@@ -49,21 +45,3 @@ class MakeBlocksSearchable(UpgradeStep):
                 parent = aq_parent(aq_inner(obj))
                 parent.reindexObject(idxs=['SearchableText'])
                 step()
-
-
-class SetBookPortlest(UpgradeStep):
-
-    def __call__(self):
-        catalog = self.getToolByName('portal_catalog')
-        brains = catalog(portal_type='Book')
-        for brain in brains:
-            book = brain.getObject()
-            manager = getUtility(IPortletManager, name='plone.leftcolumn')
-            mapping = getMultiAdapter((book, manager),
-                                  IPortletAssignmentMapping).__of__(book)
-            path = '/'.join(book.getPhysicalPath())[
-                len(book.portal_url.getPortalPath()):]
-            navi = mapping.get('navigation')
-            if navi and navi.root == path:
-                continue
-            add_navigation_portlet(book, None)

--- a/ftw/book/upgrades/to2201.py
+++ b/ftw/book/upgrades/to2201.py
@@ -1,0 +1,23 @@
+from ftw.book.eventhandler import add_navigation_portlet
+from ftw.upgrade import UpgradeStep
+from plone.portlets.interfaces import IPortletAssignmentMapping
+from plone.portlets.interfaces import IPortletManager
+from zope.component import getUtility, getMultiAdapter
+
+
+class SetBookPortlets(UpgradeStep):
+
+    def __call__(self):
+        catalog = self.getToolByName('portal_catalog')
+        brains = catalog(portal_type='Book')
+        for brain in brains:
+            book = brain.getObject()
+            manager = getUtility(IPortletManager, name='plone.leftcolumn')
+            mapping = getMultiAdapter((book, manager),
+                                  IPortletAssignmentMapping).__of__(book)
+            path = '/'.join(book.getPhysicalPath())[
+                len(book.portal_url.getPortalPath()):]
+            navi = mapping.get('navigation')
+            if navi and navi.root == path:
+                continue
+            add_navigation_portlet(book, None)


### PR DESCRIPTION
This branch fixes the Problem that after a book has been copied or moved, it still has the Navigation of the Original Location which means that we have wrong or no entries in the navigation portlet.
I also added a upgrade step, which should find broken books and fix their navigation.
