### PR TITLE
Table only for Manager?

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.2.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Let Contributors add Table objects by default.
+  [jone]
 
 
 2.2.11 (2013-01-24)

--- a/ftw/book/profiles/default/metadata.xml
+++ b/ftw/book/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2300</version>
+  <version>2301</version>
     <dependencies>
       <dependency>profile-simplelayout.base:default</dependency>
       <dependency>profile-Products.DataGridField:default</dependency>

--- a/ftw/book/profiles/default/rolemap.xml
+++ b/ftw/book/profiles/default/rolemap.xml
@@ -19,11 +19,12 @@
 
         <permission name="ftw.book: Add Table" acquire="False">
             <role name="Manager" />
+            <role name="Contributor" />
         </permission>
-        
+
         <permission name="ftw.book: Modify LaTeX Injection" acquire="False">
             <role name="Manager" />
         </permission>
-        
+
     </permissions>
 </rolemap>

--- a/ftw/book/upgrades/configure.zcml
+++ b/ftw/book/upgrades/configure.zcml
@@ -59,4 +59,23 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 2300 -> 2301 -->
+    <genericsetup:upgradeStep
+        title="Allow Contributors to add tables by default."
+        description=""
+        source="2300"
+        destination="2301"
+        handler="ftw.book.upgrades.to2301.UpdateRolemap"
+        profile="ftw.book:default"
+        />
+
+    <genericsetup:registerProfile
+        name="2301"
+        title="ftw.book.upgrades.2301"
+        description=""
+        directory="profiles/2301"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 </configure>

--- a/ftw/book/upgrades/profiles/2301/rolemap.xml
+++ b/ftw/book/upgrades/profiles/2301/rolemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<rolemap>
+    <permissions>
+
+        <permission name="ftw.book: Add Table" acquire="False">
+            <role name="Manager" />
+            <role name="Contributor" />
+        </permission>
+
+    </permissions>
+</rolemap>

--- a/ftw/book/upgrades/to2301.py
+++ b/ftw/book/upgrades/to2301.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateRolemap(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-ftw.book.upgrades:2301')


### PR DESCRIPTION
The defaults are'nt allowing contributors adding tables. Is this intendend or a bug? When its intendend: Why?
https://github.com/4teamwork/ftw.book/blob/master/ftw/book/profiles/default/rolemap.xml#L21
