### PR TITLE
HTMLBlock: reset HTML otuput type of after making it more strict in simplelayout_schemas.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.2.12 (unreleased)
 -------------------
 
+- HTMLBlock: reset HTML otuput type of after making it more strict in simplelayout_schemas.
+  [jone]
+
 - Let Contributors add Table objects by default.
   [jone]
 

--- a/ftw/book/content/htmlblock.py
+++ b/ftw/book/content/htmlblock.py
@@ -37,6 +37,9 @@ htmlblock_schema += atapi.Schema((
 
 htmlblock_schema += simplelayout_schemas.textSchema.copy()
 
+htmlblock_schema['text'].validators = ()
+htmlblock_schema['text'].default_output_type = 'text/html'
+
 htmlblock_schema['text'].widget = atapi.TextAreaWidget(
     label=_at(u'label_body_text', default=u'Body Text'),
     description='',


### PR DESCRIPTION
In 4teamwork/simplelayout.types.common#2 the TextField was configured more strict in
simplelayout schemas in general.

Since the purpose of the HTMLBlock is to use HTML which may not pass the validation,
this PR removes the validator and resets the output back to `text/html`.
