### PR TITLE
Table footnotes: use text/x-html-safe output format and only allow text/htmlinput.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.2.12 (unreleased)
 -------------------
 
+- Table footnotes: use text/x-html-safe output format and only allow text/html input.
+  [jone]
+
 - Let Contributors add Table objects by default.
   [jone]
 

--- a/ftw/book/content/table.py
+++ b/ftw/book/content/table.py
@@ -70,8 +70,11 @@ table_schema = (ATContentTypeSchema.copy() +
                 schemata='default',
                 required=False,
                 searchable=True,
+                allowable_content_types=('text/html', ),
+                default_content_type='text/html',
+                validators=('isTidyHtmlWithCleanup', ),
                 default_input_type='text/html',
-                default_output_type='text/html',
+                default_output_type='text/x-html-safe',
                 widget=atapi.RichWidget(
                     label=_(u'label_footnote_text', default=u'Footnote Text'),
                     ),


### PR DESCRIPTION
- Add validator and use `text/x-html-safe` output format for preventing XSS
- Use only `text/html` as allowable content types, so that the format is not selectable in the WYSIWYG field

/cc @maethu
