### PR TITLE
Register HTMLBlock view only for IWithinBookLayer.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 2.2.13 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Register HTMLBlock view only for IWithinBookLayer.
+  This allows us to reuse the block outside of a book with default simplelayout block view.
+  The advantage is that the title is not book-style-numbered (dynamic_title).
+  [jone]
 
 
 2.2.12 (2013-04-16)

--- a/ftw/book/browser/configure.zcml
+++ b/ftw/book/browser/configure.zcml
@@ -42,6 +42,7 @@
       template="paragraph.pt"
       class=".blockview.BookBlockView"
       permission="zope2.View"
+      layer="..interfaces.IWithinBookLayer"
       />
 
   <browser:page


### PR DESCRIPTION
This allows us to reuse the block outside of a book with default simplelayout block view.
The advantage is that the title is not book-style-numbered (dynamic_title).

/cc @maethu 
