### PR TITLE
lawgiver update: move "Modify LaTeX Injection" permission

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.2.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Move "Modify LaTeX Injection" permission to lawgiver action group
+  "manage content settings", according to changes in ftw.lawgiver.
+  [jone]
 
 
 2.2.15 (2013-05-27)

--- a/ftw/book/lawgiver.zcml
+++ b/ftw/book/lawgiver.zcml
@@ -18,7 +18,7 @@
         />
 
     <lawgiver:map_permissions
-        action_group="manage"
+        action_group="manage content settings"
         permissions="ftw.book: Modify LaTeX Injection"
         />
 


### PR DESCRIPTION
Move `Modify LaTeX Injection` permission to lawgiver action group `manage content settings`, according to changes in ftw.lawgiver.

@phabegger what do you think about this action group?
I tried to not introduce a new action group and reuse existing ones (and `manage` is gone in ftw.lawgiver).
`manage content settings` is maybe not perfectly right but contains similar permissions regarding superuser level :smiley: 

btw. the `Modify LaTeX Injection` permission allows to insert arbitrary LaTeX code to each object in the book which will be included in the PDF.
