### PR TITLE
Fix default layout schema extender to not extend in the factory.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 2.2.16 (unreleased)
 -------------------
 
+- Fix default layout schema extender to not extend in the factory.
+  The values are not set correctly when in the factory.
+  [jone]
+
 - Move "Modify LaTeX Injection" permission to lawgiver action group
   "manage content settings", according to changes in ftw.lawgiver.
   [jone]

--- a/ftw/book/latex/defaultlayout.py
+++ b/ftw/book/latex/defaultlayout.py
@@ -115,6 +115,9 @@ class DefaultBookLayoutExtender(object):
         # Looks like this method is called before
         # BookTraverse.publishTraverse() marks the request with the interface.
 
+        if self.context.isTemporary():
+            return []
+
         layout_layer_name = getattr(self.context, 'latex_layout', None)
         if layout_layer_name:
             layout_layer = resolve(layout_layer_name)


### PR DESCRIPTION
The values are not set correctly when in the factory, therefore the extender should not be applied while in factory.
This is because of how the layout selection and the schema extenders work.

This is the initial behavior, the fields did occur in the factory because of a lingua Plone compatibility fix - this pull request restores the original behavior.

@maethu could you take a look?
