### PR TITLE
Fix literal book titles for default sphinx layout.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.2.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix literal book titles for default sphinx layout.
+  The title is taken literally and does not need to be converted to LaTeX.
+  [jone]
 
 
 2.2.16 (2013-08-26)

--- a/ftw/book/latex/defaultlayout.py
+++ b/ftw/book/latex/defaultlayout.py
@@ -158,7 +158,7 @@ class DefaultBookLayout(MakoLayoutBase):
 
         args = {
             'context_is_book': self.context == book,
-            'title': convert(book.Title()),
+            'title': book.Title(),
             'use_titlepage': book.getUse_titlepage(),
             'logo': logo_filename,
             'logo_width': logo_width,

--- a/ftw/book/tests/test_default_layout.py
+++ b/ftw/book/tests/test_default_layout.py
@@ -45,7 +45,7 @@ class TestDefaultBookLayout(MockTestCase):
             self.expect(book.Schema().getField(key).get(book)).result(value)
 
         return book
-        
+
     def _mock_portal_languages_tool(self):
         language_tool = self.mocker.mock()
         self.mock_tool(language_tool, 'portal_languages')
@@ -126,7 +126,7 @@ class TestDefaultBookLayout(MockTestCase):
              'babel': 'english',
              'logo': False,
              'logo_width': 0})
-             
+
     def test_get_render_arguments_babel(self):
         book = self._mock_book()
 
@@ -238,3 +238,15 @@ class TestDefaultBookLayout(MockTestCase):
             r'\def\sphinxlogo{\includegraphics{' + \
                 r'titlepage_logo.jpg}}',
             latex)
+
+    def test_title_is_inserted_literally(self):
+        # The spinx layout expects the title to not be LaTeX, but the string
+        # literal.
+
+        self._mock_portal_languages_tool()
+        book = self._mock_book({'Title': 'Foo-Bar'})
+        self.replay()
+
+        layout = DefaultBookLayout(book, object(), object())
+
+        self.assertEqual('Foo-Bar', layout.get_render_arguments()['title'])


### PR DESCRIPTION
The title is taken literally and does not need to be converted to LaTeX.
Closes #39
