### PR TITLE
Table object: fix default border layout to be included in the allowed layouts

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.2.18 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Table object: fix default border layout to be included in the allowed border layouts.
+  [jone]
 
 
 2.2.17 (2013-09-11)

--- a/ftw/book/content/table.py
+++ b/ftw/book/content/table.py
@@ -199,7 +199,7 @@ table_schema = (ATContentTypeSchema.copy() +
             atapi.StringField(
                 name='borderLayout',
                 schemata='Layout',
-                default='lines',
+                default='fancy_listing',
                 enforceVocabulary=True,
                 vocabulary=BORDER_LAYOUTS,
                 widget=atapi.SelectionWidget(


### PR DESCRIPTION
Currently one has to select a border layout upon content creation because the default is invalid.
I think the "lines" layout was renamed to "fancy_listing" so that it matches the default Plone styling classes.
