### PR TITLE
Table object: add "Warning" to manually created warning portal messages.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.2.18 (unreleased)
 -------------------
 
+- Table object: add "Warning" to manually created warning portal messages.
+  [jone]
+
 - Table object: fix default border layout to be included in the allowed border layouts.
   [jone]
 

--- a/ftw/book/browser/table_content.pt
+++ b/ftw/book/browser/table_content.pt
@@ -7,6 +7,8 @@
         <table tal:condition="table"
                tal:replace="structure table" />
         <dl tal:condition="not:table" class="portalMessage warning">
+            <dt i18n:domain="plone"
+                i18n:translate="">Warning</dt>
             <dd i18n:translate="">
                 The table has no content yet.
                 Edit the table block for adding content.

--- a/ftw/book/skins/ftw_book_templates/datagridwidget_bibliothek_table.pt
+++ b/ftw/book/skins/ftw_book_templates/datagridwidget_bibliothek_table.pt
@@ -56,6 +56,7 @@
                     <tr tal:condition="python:len([1 for x in columnActivity if x])==0">
                         <td colspan="5">
                             <dl class="portalMessage warning">
+                                <dt i18n:domain="plone" i18n:translate="">Warning</dt>
                                 <dd i18n:domain="ftw.book"
                                     i18n:translate="info_actvate_columns_first">
                                     Please activate the required columns under 'Layout' and and save


### PR DESCRIPTION
This follows the Plone standard and matches better with themes styling
portal messages in general.

![bildschirmfoto 2013-09-13 um 10 15 42](https://f.cloud.github.com/assets/7469/1136765/b3232a16-1c4c-11e3-941e-18553f2d611f.png)
