### PR TITLE
Fix bug in keywords tab when the same keyword is in multiple books.

### DIFF
--- a/ftw/book/browser/keywords.py
+++ b/ftw/book/browser/keywords.py
@@ -102,7 +102,8 @@ class KeywordsTab(BrowserView):
             return self.chapters[os.path.dirname(path)]['title']
 
     def _get_load_query(self):
-        return {'book_keywords': self.request.form.get('book_keywords'),
+        return {'path': '/'.join(self.context.getPhysicalPath()),
+                'book_keywords': self.request.form.get('book_keywords'),
                 'sort_on': 'getObjPositionInParent'}
 
     def _sort_brains(self, brains):


### PR DESCRIPTION
The keywords tab did not limit the search of blocks to the current book when selecting a keyword.
When having multiple books with the same keyword this could produce an exception within the internal chapters cache when selecting this keyword.

The solution is to properly limit the scope of the catalog query to the current book.

/ @maethu 
I did not add a changelog since the keywords tab is unreleased in the v3.x target branch.
