### PR TITLE
Tables: no longer use description as caption.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 3.0.0 (unreleased)
 ------------------
 
+- Tables: no longer use description as caption.
+  The description field is no longer visible for tables,
+  therefore it should not be used as caption.
+  [jone]
+
 - Drop Plone 4.1 support.
   [jone]
 

--- a/ftw/book/table/generator.py
+++ b/ftw/book/table/generator.py
@@ -64,7 +64,6 @@ class TableGenerator(object):
             css_classes.append('no-lifting')
 
         attrs = {
-                'summary': self.context.Description(),
                 'class': ' '.join(css_classes),
         }
         return self._create_node('table', self.doc, **attrs)

--- a/ftw/book/tests/test_table_generator.py
+++ b/ftw/book/tests/test_table_generator.py
@@ -208,7 +208,6 @@ class TestTableGenerator(MockTestCase):
         generator = TableGenerator(table)
         html_table = generator.render()
 
-        summary = 'summary="Its ä Description">'
         title = [
             '<caption>',
                 'My Test Täble',
@@ -275,7 +274,6 @@ class TestTableGenerator(MockTestCase):
             '</tfoot>',
         ]
 
-        self.assertIn(summary, html_table)
         self.assertIn(''.join(title), html_table)
         self.assertIn(''.join(colgroup), html_table)
         self.assertIn(''.join(thead), html_table)


### PR DESCRIPTION
When updating existing books somehow the description was suddenly used in the PDF as caption, which was not the case before. Since we've hidden the description in v3.x anyways, we should not use existing values as caption (PDF) or summary (HTML) anymore.

@maethu can you take a look?
