### PR TITLE
Keywords: load select2 javascript translations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.0.0 (unreleased)
 ------------------
 
+- Keywords: load select2 javascript translations.
+  [jone]
+
 - Tables: no longer use description as caption.
   The description field is no longer visible for tables,
   therefore it should not be used as caption.

--- a/ftw/book/browser/templates/keywords.pt
+++ b/ftw/book/browser/templates/keywords.pt
@@ -10,6 +10,13 @@
             <link href="++resource++ftw.book-select2/select2.css" rel="stylesheet"/>
             <script src="++resource++ftw.book-select2/select2.js"
                     type="text/javascript" language="javascript"></script>
+            <script
+                tal:define="lang context/portal_languages/getPreferredLanguage;
+                            lang python: lang.split('-')[0]"
+                tal:condition="python: lang != 'en'"
+                tal:attributes="src string:++resource++ftw.book-select2/select2_locale_${lang}.js"
+                type="text/javascript" language="javascript"></script>
+
             <script src="++resource++ftw.book-resources/keywords.js"
                     type="text/javascript" language="javascript"></script>
         </metal:SLOT>


### PR DESCRIPTION
Load select2 javascript translations when preferred language is non-english.
![bildschirmfoto 2014-04-22 um 16 54 28](https://cloud.githubusercontent.com/assets/7469/2766355/0c9ac42a-ca2e-11e3-9247-e58a36b87fc7.png)

@Tschanzt can you take a look, please?
