### PR TITLE
Fix scroll position when invoking reader on a block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
+- Fix scroll position when invoking reader on a block.
+  [jone]
+
 - Use ftw.profilehook instead of custom import steps (setuphandlers).
   [jone]
 

--- a/ftw/book/browser/reader/resources/reader.js
+++ b/ftw/book/browser/reader/resources/reader.js
@@ -97,12 +97,12 @@
     var data = {};
 
     if (direction == 'down') {
-      url = 'book_reader_view/render_next';
+      url = get_baseurl() + 'book_reader_view/render_next';
       data = {after_uid: last_bottom_uid,
               loaded_blocks: get_loaded_uids()};
 
     } else if (direction == 'up') {
-      url = 'book_reader_view/render_previous';
+      url = get_baseurl() + 'book_reader_view/render_previous';
       data = {before_uid: last_top_uid,
               loaded_blocks: get_loaded_uids()};
     }
@@ -317,6 +317,14 @@
       }
     }
   };
+
+  function get_baseurl() {
+    var baseurl = $('head base').attr('href');
+    if(baseurl.substr(baseurl.length-1, 1) != '/') {
+      baseurl += '/';
+    }
+    return baseurl;
+  }
 
   /* stay in reader when clicking on book internal links */
   $('a.book-internal').live('click', function(e) {


### PR DESCRIPTION
The problem was that the block is not folderish and therefore was not added in the URL automatically.
The fix is to use the base-url from the <base> tag.

The result was that even though that it did always scroll to the chapter when invoking the view, even when the view was invoked on a block. When having large blocks above the block was not visible at all.

For example the keywords tab links to the reader view directly on a block.

@maethu might take a look?
