### PR TITLE
Fix namespace adapters for Chapter and Book objects

### DIFF
--- a/ftw/book/latex/book.py
+++ b/ftw/book/latex/book.py
@@ -1,11 +1,12 @@
 from ftw.book.interfaces import IBook
+from ftw.pdfgenerator.interfaces import ILaTeXLayout
 from ftw.pdfgenerator.view import RecursiveLaTeXView
 from zope.component import adapts
 from zope.interface import Interface
 
 
 class BookLaTeXView(RecursiveLaTeXView):
-    adapts(IBook, Interface, Interface)
+    adapts(IBook, Interface, ILaTeXLayout)
 
     def render(self):
         return self.render_children()

--- a/ftw/book/latex/chapter.py
+++ b/ftw/book/latex/chapter.py
@@ -1,13 +1,14 @@
 from ftw.book.helpers import BookHelper
 from ftw.book.interfaces import IChapter
 from ftw.book.latex import utils
+from ftw.pdfgenerator.interfaces import ILaTeXLayout
 from ftw.pdfgenerator.view import RecursiveLaTeXView
 from zope.component import adapts
 from zope.interface import Interface
 
 
 class ChapterLaTeXView(RecursiveLaTeXView):
-    adapts(IChapter, Interface, Interface)
+    adapts(IChapter, Interface, ILaTeXLayout)
 
     def render(self):
         latex = self.get_heading_counters_latex()


### PR DESCRIPTION
Adapting to Interface for the layout seems to be too generic. It takes
precedence over namespace adapters such as ++add++ for example:

> > > ttool = getToolByName(self.context, 'portal_types')
> > > ti = ttool.getTypeInfo("Image")
> > > queryMultiAdapter((self.context, self.request, ti))
> > > <ftw.book.latex.chapter.ChapterLaTeXView object at 0x7f9e32c089d0>

(cherry picked from commit 1474162630cad86fe0fd564027b664da4b1a9c17)
