### PR TITLE
Sort keywords normalized for a more intuitive order.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
+- Sort keywords normalized for a more intuitive order.
+  [lknoepfel]
+
 - Make LaTeX view adapter's layout descriminator more specific
   in order to avoid clash with similar adapters such as `++add++`.
   [cillianderoiste]


### PR DESCRIPTION
Prior to this fix all keywords starting with accents or other non-ascii character were sorted to the end of the keywords list. This PR adds a sorting key which normalizes them first, causing the accents to be placed next to their ascii counterparts.
![screen shot 2014-12-03 at 09 27 21](https://cloud.githubusercontent.com/assets/1375745/5277866/129e5aac-7ad3-11e4-8374-bbc2547e3178.png)

@maethu 
