### PR TITLE
Listingblock PDF: remove caption added in ftw.contentpage 1.9.0.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
+- Listingblock PDF: remove caption added in ftw.contentpage 1.9.0.
+  [jone]
+
 - Sort keywords normalized for a more intuitive order.
   [lknoepfel]
 

--- a/ftw/book/latex/listingblock.py
+++ b/ftw/book/latex/listingblock.py
@@ -38,6 +38,11 @@ def remove_table_summary(doc):
 
 
 @parsed_html
+def remove_table_caption(doc):
+    lxml.etree.strip_tags(doc, 'caption')
+
+
+@parsed_html
 def add_table_column_widths(doc):
     for table in doc.xpath('//table'):
         no_width = []
@@ -74,5 +79,6 @@ class ListingBlockLaTeXView(MakoLaTeXView):
         table_html = view.render_table()
         table_html = remove_html_links(table_html)
         table_html = remove_table_summary(table_html)
+        table_html = remove_table_caption(table_html)
         table_html = add_table_column_widths(table_html)
         return self.convert(table_html)


### PR DESCRIPTION
The caption was added to listing blocks in ftw.contentpage 1.9.0 in pull request https://github.com/4teamwork/ftw.contentpage/pull/196 for accessibility reasons, hidden by CSS.

We now remove the caption tag for PDF generation.

@maethu fixes tests