### PR TITLE
Interal Links in PDF: fix links to paths containing spaces.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Interal Links in PDF: fix links to paths containing spaces.
+  [jone]
 
 
 3.0.2 (2015-01-21)

--- a/ftw/book/latex/hyperlink_subconverter.py
+++ b/ftw/book/latex/hyperlink_subconverter.py
@@ -1,6 +1,6 @@
-from Products.CMFCore.utils import getToolByName
 from ftw.book import _
 from ftw.pdfgenerator.html2latex.subconverters import hyperlink
+from Products.CMFCore.utils import getToolByName
 from zope.i18n import translate
 
 
@@ -19,6 +19,7 @@ class BookHyperlinkConverter(hyperlink.HyperlinkConverter):
                            '/'.join((context.getPhysicalPath())))
         path = path.split('\#', 1)[0]
         path = path.split('?', 1)[0]
+        path = path.replace(r'\%20', ' ')
         path = path.rstrip('/')
 
         return (r'\hyperref[path:%(path)s]{%(label)s'

--- a/ftw/book/tests/test_latex_internal_hyperlinks.py
+++ b/ftw/book/tests/test_latex_internal_hyperlinks.py
@@ -41,3 +41,31 @@ class TestBookInternalHyperlinksLaTeX(TestCase):
             r'\footnote{See page'
             r' \pageref{path:/plone/the-book/the-chapter}}}',
             latex_view.render())
+
+    def test_spaces_are_not_escaped(self):
+        # Escaping spaces in URLs with %20 in LaTeX is bad because % is a comment.
+        chapter = create(Builder('chapter')
+                         .within(self.book)
+                         .titled('the chapter'))
+
+        document = create(Builder('file')
+                          .within(chapter)
+                          .titled('The File')
+                          .with_id('the file'))
+
+        html = '<a class="internal-link" href="resolveuid/{0}">Link</a>'.format(
+            IUUID(document))
+        block = create(Builder('book textblock')
+                       .within(chapter)
+                       .having(text=html))
+
+        request = block.REQUEST
+        assembler = getMultiAdapter((self.book, request), IPDFAssembler)
+        latex_view = getMultiAdapter((block, request, assembler.get_layout()),
+                                     ILaTeXView)
+
+        self.assertEqual(
+            r'\hyperref[path:/plone/the-book/the-chapter/the file]{Link'
+            r'\footnote{See page'
+            r' \pageref{path:/plone/the-book/the-chapter/the file}}}',
+            latex_view.render().strip())


### PR DESCRIPTION
Spaces should not be escaped in internal links since the labels also contain the raw spaces.

It is also not wise to escape the with `%20` since this is `%` is the comment character in LaTeX.