### PR TITLE
Added book context manager.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.1.1 (unreleased)
 ------------------
 
+- Added book context manager.
+  [lknoepfel]
+
 - Include files from listing blocks in zip export.
   [mbaechtold]
 

--- a/ftw/book/layer.py
+++ b/ftw/book/layer.py
@@ -1,9 +1,10 @@
-from ZPublisher.BaseRequest import DefaultPublishTraverse
 from ftw.book.interfaces import IBook, IWithinBookLayer
+from ftw.pdfgenerator.utils import provide_request_layer
 from zope.component import adapts
 from zope.dottedname.resolve import resolve
-from ftw.pdfgenerator.utils import provide_request_layer
+from zope.interface import directlyProvidedBy, directlyProvides
 from zope.publisher.interfaces import IRequest
+from ZPublisher.BaseRequest import DefaultPublishTraverse
 
 
 class BookTraverse(DefaultPublishTraverse):
@@ -11,11 +12,29 @@ class BookTraverse(DefaultPublishTraverse):
 
     def publishTraverse(self, request, name):
 
-        layout_layer_name = getattr(self.context, 'latex_layout', '')
-        if layout_layer_name:
-            layout_layer = resolve(layout_layer_name)
-            provide_request_layer(request, layout_layer)
-
-        provide_request_layer(request, IWithinBookLayer)
+        provideBookLayers(self.context, request)
 
         return super(BookTraverse, self).publishTraverse(request, name)
+
+
+def provideBookLayers(context, request):
+    layout_layer_name = getattr(context, 'latex_layout', '')
+    if layout_layer_name:
+        layout_layer = resolve(layout_layer_name)
+        provide_request_layer(request, layout_layer)
+
+    provide_request_layer(request, IWithinBookLayer)
+
+
+class BookContext(object):
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __enter__(self):
+        self.original_interfaces = list(directlyProvidedBy(self.request))
+        provideBookLayers(self.context, self.request)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        directlyProvides(self.request, *self.original_interfaces)

--- a/ftw/book/tests/test_context_manager.py
+++ b/ftw/book/tests/test_context_manager.py
@@ -1,4 +1,4 @@
-from ftw.book.layer import BookContext
+from ftw.book.layer import providing_book_layers
 from ftw.book.testing import FTW_BOOK_FUNCTIONAL_TESTING
 from unittest2 import TestCase
 from zope.interface import directlyProvidedBy
@@ -14,9 +14,9 @@ class TestContextManager(TestCase):
     def test_context_manager_adds_book_layers(self):
         thelist = list(directlyProvidedBy(self.portal.REQUEST))
 
-        with BookContext(self.portal, self.portal.REQUEST):
+        with providing_book_layers(self.portal, self.portal.REQUEST):
             diff = [it for it in list(
-                directlyProvidedBy(self.portal.REQUEST)) if it not in thelist]
+                    directlyProvidedBy(self.portal.REQUEST)) if it not in thelist]
 
             self.assertEquals(
                 ['<InterfaceClass ftw.book.interfaces.IWithinBookLayer>'],

--- a/ftw/book/tests/test_context_manager.py
+++ b/ftw/book/tests/test_context_manager.py
@@ -1,0 +1,26 @@
+from ftw.book.layer import BookContext
+from ftw.book.testing import FTW_BOOK_FUNCTIONAL_TESTING
+from unittest2 import TestCase
+from zope.interface import directlyProvidedBy
+
+
+class TestContextManager(TestCase):
+
+    layer = FTW_BOOK_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_context_manager_adds_book_layers(self):
+        thelist = list(directlyProvidedBy(self.portal.REQUEST))
+
+        with BookContext(self.portal, self.portal.REQUEST):
+            diff = [it for it in list(
+                directlyProvidedBy(self.portal.REQUEST)) if it not in thelist]
+
+            self.assertEquals(
+                ['<InterfaceClass ftw.book.interfaces.IWithinBookLayer>'],
+                [str(item) for item in diff])
+
+        self.assertEquals(thelist,
+                          list(directlyProvidedBy(self.portal.REQUEST)))

--- a/ftw/book/tests/test_zipexport.py
+++ b/ftw/book/tests/test_zipexport.py
@@ -12,7 +12,10 @@ class TestBookZipexport(TestCase):
     layer = FTW_BOOK_FUNCTIONAL_TESTING
 
     def setUp(self):
-        self.book = create(Builder('book').titled('The Book'))
+        self.folder = create(Builder('folder'))
+
+        self.book = create(Builder('book').titled('The Book')
+                           .within(self.folder))
         chapter1 = create(Builder('chapter').titled('First Chapter')
                           .within(self.book))
 
@@ -40,13 +43,14 @@ class TestBookZipexport(TestCase):
 
     @browsing
     def test_zipexport_integration(self, browser):
-        browser.login().visit(self.book, view='zip_export')
+        browser.login().visit(self.folder, view='zip_export')
 
         self.assertEquals('application/zip', browser.headers['Content-Type'])
 
         zipfile = ZipFile(StringIO(browser.contents))
         self.assertEquals(
-            ['the-book.pdf', 'First Chapter/image.gif',
-             'First Chapter/The SubChapter/image.gif',
-             'Second Chapter/image.gif'],
+            ['the-book.pdf',
+             'The Book/First Chapter/image.gif',
+             'The Book/First Chapter/The SubChapter/image.gif',
+             'The Book/Second Chapter/image.gif'],
             zipfile.namelist())

--- a/ftw/book/zipexport.py
+++ b/ftw/book/zipexport.py
@@ -1,8 +1,8 @@
-from ftw.zipexport.representations.archetypes import FolderZipRepresentation
 from ftw.book.interfaces import IBook
-from ftw.book.layer import BookContext
+from ftw.book.layer import providing_book_layers
 from ftw.pdfgenerator.interfaces import IPDFAssembler
 from ftw.zipexport.interfaces import IZipRepresentation
+from ftw.zipexport.representations.archetypes import FolderZipRepresentation
 from StringIO import StringIO
 from zope.component import adapts
 from zope.component import getMultiAdapter
@@ -17,7 +17,7 @@ class BookZipRepresentation(FolderZipRepresentation):
     def get_files(self, path_prefix=u"", recursive=True, toplevel=True):
         filename = u'{0}.pdf'.format(self.context.getId())
 
-        with BookContext(self.context, self.request):
+        with providing_book_layers(self.context, self.request):
             assembler = getMultiAdapter((self.context, self.request),
                                         IPDFAssembler)
 

--- a/ftw/book/zipexport.py
+++ b/ftw/book/zipexport.py
@@ -1,5 +1,6 @@
 from ftw.zipexport.representations.archetypes import FolderZipRepresentation
 from ftw.book.interfaces import IBook
+from ftw.book.layer import BookContext
 from ftw.pdfgenerator.interfaces import IPDFAssembler
 from ftw.zipexport.interfaces import IZipRepresentation
 from StringIO import StringIO
@@ -16,14 +17,15 @@ class BookZipRepresentation(FolderZipRepresentation):
     def get_files(self, path_prefix=u"", recursive=True, toplevel=True):
         filename = u'{0}.pdf'.format(self.context.getId())
 
-        assembler = getMultiAdapter((self.context, self.request),
-                                    IPDFAssembler)
+        with BookContext(self.context, self.request):
+            assembler = getMultiAdapter((self.context, self.request),
+                                        IPDFAssembler)
 
-        yield (u'{0}/{1}'.format(path_prefix, filename),
-               StringIO(assembler.build_pdf()))
+            yield (u'{0}/{1}'.format(path_prefix, filename),
+                   StringIO(assembler.build_pdf()))
 
-        folder_contents = super(BookZipRepresentation, self).get_files(
-            path_prefix, recursive, toplevel)
+            folder_contents = super(BookZipRepresentation, self).get_files(
+                path_prefix, recursive, toplevel)
 
-        for item in folder_contents:
-            yield item
+            for item in folder_contents:
+                yield item


### PR DESCRIPTION
`ftw.book` uses various interfaces on the request to identify content inside a book. Those interfaces are normally applied while traversing. 
The zipexport doesn't traverse, but collects the resources recursive. With this the interfaces are missing which causes `ftw.pdfgenerator` to faceplant.

This PR introduces a context manager which applies those needed interfaces and removes them on exit.

@jone 