### PR TITLE
fix listingblock tests

### DIFF
--- a/ftw/book/latex/listingblock.py
+++ b/ftw/book/latex/listingblock.py
@@ -21,7 +21,7 @@ def parsed_html(func):
         doc = lxml.html.parse(StringIO(html))
         func(doc)
         html = lxml.html.tostring(doc.xpath('//body/div')[0])
-        return re.sub('^<div>(.*)</div>$', '\g<1>', html)
+        return re.sub(r'^<div>(.*)</div>$', '\g<1>', html, flags=re.DOTALL)
     return parser
 
 

--- a/ftw/book/tests/test_listingblock_latex.py
+++ b/ftw/book/tests/test_listingblock_latex.py
@@ -49,8 +49,9 @@ class TestAddTableColumnWidths(TestCase):
                 '<col width="63%">',
                 '</colgroup></table>'))
 
-        self.assertEquals(expected, add_table_column_widths(input))
-
+        self.assertEquals(
+            expected,
+            add_table_column_widths(input).replace('\n', ''))
 
 
 class TestListingBlockLaTeXView(TestCase):


### PR DESCRIPTION
Somehow something changed regarding newlines in lxml, leading to
failing tests:

It seems as if newlines were cleaned up before and now longer are.
The problem seems to depend on the lxml version and therefore not appear
on every installation.

1) `parsed_html`-decorator: The decorator parses HTML to an lxml
document, wich is then modified by the wrapped function and the
decorator then renders the document. For that the HTML is wrapped with a
`<div>` in order to avoid a multiple-root-node error. When removing the
`<div>` afterwards, we need to make sure that we do that in a multiline
supporting way (`re.DOTALL`) in order to support multilines in the
HTML. I'm not sure why this was not a problem before.

2) Since something in lxml changed we now have line breaks in the
resulting HTML. We just remove them in order to support both lxml
versions - we do not really care.