### PR TITLE
Configurable table of contents depth

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Made table of contents depth configurable for web.
+  [lknoepfel]
 
 
 3.4.1 (2016-03-30)

--- a/ftw/book/content/book.py
+++ b/ftw/book/content/book.py
@@ -18,6 +18,15 @@ BookSchema = (folder.ATFolderSchema.copy() +
               NextPreviousAwareSchema.copy() +
               atapi.Schema((
 
+            atapi.IntegerField(
+                name='web_toc_depth',
+                default=0,
+                searchable=False,
+                widget=atapi.IntegerWidget(
+                    label=_(u'label_web_toc_depth',
+                            default=u'Table of contents depth'),
+                    description=_(u'help_web_toc_depth', default=u''))),
+
             atapi.StringField(
                 name='latex_layout',
                 required=True,

--- a/ftw/book/locales/de/LC_MESSAGES/ftw.book.po
+++ b/ftw/book/locales/de/LC_MESSAGES/ftw.book.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
-"POT-Creation-Date: 2014-06-11 11:58+0000\n"
+"POT-Creation-Date: 2016-04-28 07:54+0000\n"
 "PO-Revision-Date: 2012-11-14 14:46+0100\n"
 "Last-Translator: Julian Infanger <julian.infanger@4teamwork.ch>\n"
 "Language-Team: Julian Infanger <julian.infanger@4teamwork.ch>\n"
@@ -48,6 +48,10 @@ msgstr "2mm einr. + grau"
 msgid "2mm indent"
 msgstr "2mm einrücken"
 
+#: ./ftw/book/upgrades/configure.zcml:203
+msgid "Add footnote plugin."
+msgstr ""
+
 #: ./ftw/book/content/table.py:289
 msgid "Bold"
 msgstr "Fett"
@@ -61,6 +65,10 @@ msgstr "Buch"
 #: ./ftw/book/upgrades/profiles/3000/types/BookTextBlock.xml
 msgid "BookTextBlock"
 msgstr "Text Block"
+
+#: ./ftw/book/upgrades/configure.zcml:194
+msgid "Change HTMLBlock icon."
+msgstr ""
 
 #. Default: "Chapter"
 #: ./ftw/book/profiles/default/types/Chapter.xml
@@ -99,6 +107,14 @@ msgstr "HTML Block"
 msgid "Import"
 msgstr "Importieren"
 
+#: ./ftw/book/upgrades/configure.zcml:156
+msgid "Install ftw.contentpage and make ListingBlock available in books"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:110
+msgid "Install tinymce keyword plugin"
+msgstr ""
+
 #: ./ftw/book/content/table.py:288
 msgid "Normal"
 msgstr "Normal"
@@ -106,6 +122,18 @@ msgstr "Normal"
 #: ./ftw/book/profiles/default/actions.xml
 msgid "PDF"
 msgstr "PDF"
+
+#: ./ftw/book/upgrades/configure.zcml:147
+msgid "Register BookTextBlock as linkable in TinyMCE."
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:185
+msgid "Register new 'Add Chapter' permission."
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:138
+msgid "Register new keywords tab."
+msgstr ""
 
 #: ./ftw/book/profiles/default/types/Remark.xml
 msgid "Remark"
@@ -139,6 +167,10 @@ msgstr "Die Tabelle hat noch keinen Inhalt. Definieren Sie den Inhalt, indem Sie
 msgid "This option inserts a column break when two column layout is active."
 msgstr "Dies Option fügt einen Spaltenumbruch vor diesem Inhalt ein, sofern dieser im Zweispaltigen Layout angezeigt wird. Wird der Inhalt davor in der rechten Spalte dargestellt, so wird ein Seitenumbruch eingefügt."
 
+#: ./ftw/book/configure.zcml:54
+msgid "Uninstall ftw.book"
+msgstr ""
+
 #: ./ftw/book/browser/table_export_import.py:93
 msgid "You didn't choose a column."
 msgstr "Sie haben keine Spalte ausgewählt"
@@ -162,23 +194,23 @@ msgid "book_help_titlepage_logo_width"
 msgstr "Wenn Sie ein Logo für die Titelseite benutze, definieren Sie hier die gewünschte Breite in Prozent der Inhaltsbreite."
 
 #. Default: "When enabled, a keyword index will be included in the PDF."
-#: ./ftw/book/content/book.py:79
+#: ./ftw/book/content/book.py:88
 msgid "book_help_use_index"
 msgstr "Wenn diese Option angewählt ist, wird im PDF am Ende des Buches ein Stichwortverzeichnis generiert."
 
-#: ./ftw/book/content/book.py:69
+#: ./ftw/book/content/book.py:78
 msgid "book_help_use_loi"
 msgstr "Wenn diese Option angewählt ist, wird automatisch ein Abbildungsverzeichnis erstellt."
 
-#: ./ftw/book/content/book.py:59
+#: ./ftw/book/content/book.py:68
 msgid "book_help_use_lot"
 msgstr "Wenn dies Option angewählt ist, wird automatisch ein Tabbellenverzeichnis erstellt."
 
-#: ./ftw/book/content/book.py:39
+#: ./ftw/book/content/book.py:48
 msgid "book_help_use_titlepage"
 msgstr "Wenn diese Option angewählt ist, wird eine Titelseite erzeugt."
 
-#: ./ftw/book/content/book.py:49
+#: ./ftw/book/content/book.py:58
 msgid "book_help_use_toc"
 msgstr "Wenn diese Option angewählt ist, wird automatisch ein Inhaltsverzeichnis erstellt."
 
@@ -193,7 +225,7 @@ msgid "book_label_author_address"
 msgstr "Adresse des Autors"
 
 #. Default: "Layout"
-#: ./ftw/book/content/book.py:29
+#: ./ftw/book/content/book.py:38
 msgid "book_label_layout"
 msgstr "Layout"
 
@@ -213,27 +245,27 @@ msgid "book_label_titlepage_logo_width"
 msgstr "Breite Logo Titelseite (%)"
 
 #. Default: "Embedd subject index"
-#: ./ftw/book/content/book.py:77
+#: ./ftw/book/content/book.py:86
 msgid "book_label_use_index"
 msgstr "Stichwortverzeichnis einbetten"
 
 #. Default: "Embedd list of illustrations"
-#: ./ftw/book/content/book.py:67
+#: ./ftw/book/content/book.py:76
 msgid "book_label_use_loi"
 msgstr "Abbildungsverzeichnis einbetten"
 
 #. Default: "Embedd list of tables."
-#: ./ftw/book/content/book.py:57
+#: ./ftw/book/content/book.py:66
 msgid "book_label_use_lot"
 msgstr "Tabellenverzeichnis einbetten"
 
 #. Default: "Embedd a title page"
-#: ./ftw/book/content/book.py:37
+#: ./ftw/book/content/book.py:46
 msgid "book_label_use_titlepage"
 msgstr "Titelseite einbetten"
 
 #. Default: "Embedd table of contents"
-#: ./ftw/book/content/book.py:47
+#: ./ftw/book/content/book.py:56
 msgid "book_label_use_toc"
 msgstr "Inhaltsverzeichnis einbetten"
 
@@ -272,6 +304,34 @@ msgstr "Neue Zeile hinzufügen"
 #: ./ftw/book/content/table.py:220
 msgid "description_no_lifting"
 msgstr "Ist beim exportieren eines Buches als PDF die erste Zelle leer, wird die gesammte Tabelle um eine Zeile nach oben geschoben. Somit wird der Titel der Tabelle auf der gleichen Höhe wie die erste Zeile der Tabelle dargestellt. Um dieses Verhalten zu unterdrücken, aktivieren Sie diese Option."
+
+#: ./ftw/book/configure.zcml:40
+msgid "ftw.book"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:33
+msgid "ftw.book.upgrades.2200"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:63
+msgid "ftw.book.upgrades.2300"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:82
+msgid "ftw.book.upgrades.2301"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:101
+msgid "ftw.book.upgrades.3000"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:129
+msgid "ftw.book.upgrades.3002"
+msgstr ""
+
+#: ./ftw/book/content/book.py:28
+msgid "help_web_toc_depth"
+msgstr "Wieviele Kapitelebenen sollen im Inhaltsverzeichnis angezeigt werden. 0 bedeutet keine Einschränkung. Dies hat keinen Einfluss auf das PDF."
 
 #. Default: "Please activate the required columns under 'Layout' and and save the object."
 #: ./ftw/book/skins/ftw_book_templates/datagridwidget_bibliothek_table.pt:60
@@ -413,8 +473,13 @@ msgstr "Titel anzeigen"
 msgid "label_table_content"
 msgstr "Tabelleninhalt"
 
+#. Default: "Table of contents depth"
+#: ./ftw/book/content/book.py:26
+msgid "label_web_toc_depth"
+msgstr "Inhaltsverzeichnistiefe"
+
 #. Default: "See page ${pageref}"
-#: ./ftw/book/latex/hyperlink_subconverter.py:31
+#: ./ftw/book/latex/hyperlink_subconverter.py:32
 msgid "latex_page_reference"
 msgstr "Siehe Seite ${pageref}"
 
@@ -532,5 +597,4 @@ msgstr "Tabellendaten importieren / exportieren"
 #: ./ftw/book/latex/defaultlayout.py:215
 msgid "title_index"
 msgstr "Stichwortverzeichnis"
-
 

--- a/ftw/book/locales/de/LC_MESSAGES/ftw.tabbedview.po
+++ b/ftw/book/locales/de/LC_MESSAGES/ftw.tabbedview.po
@@ -23,4 +23,3 @@ msgstr "Inhaltsverzeichnis"
 msgid "keywords"
 msgstr "Stichwörter"
 
-

--- a/ftw/book/locales/de/LC_MESSAGES/plone.po
+++ b/ftw/book/locales/de/LC_MESSAGES/plone.po
@@ -20,4 +20,3 @@ msgstr "Inhaltsverzeichnis"
 msgid "tabbed_view"
 msgstr "Reiter Ansicht"
 
-

--- a/ftw/book/locales/en/LC_MESSAGES/ftw.book.po
+++ b/ftw/book/locales/en/LC_MESSAGES/ftw.book.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-06-11 11:58+0000\n"
+"POT-Creation-Date: 2016-04-28 07:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,6 +47,10 @@ msgstr ""
 msgid "2mm indent"
 msgstr ""
 
+#: ./ftw/book/upgrades/configure.zcml:203
+msgid "Add footnote plugin."
+msgstr ""
+
 #: ./ftw/book/content/table.py:289
 msgid "Bold"
 msgstr ""
@@ -59,6 +63,10 @@ msgstr ""
 #: ./ftw/book/upgrades/profiles/3000/types/BookTextBlock.xml
 msgid "BookTextBlock"
 msgstr "Text Block"
+
+#: ./ftw/book/upgrades/configure.zcml:194
+msgid "Change HTMLBlock icon."
+msgstr ""
 
 #: ./ftw/book/profiles/default/types/Chapter.xml
 msgid "Chapter"
@@ -96,12 +104,32 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
+#: ./ftw/book/upgrades/configure.zcml:156
+msgid "Install ftw.contentpage and make ListingBlock available in books"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:110
+msgid "Install tinymce keyword plugin"
+msgstr ""
+
 #: ./ftw/book/content/table.py:288
 msgid "Normal"
 msgstr ""
 
 #: ./ftw/book/profiles/default/actions.xml
 msgid "PDF"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:147
+msgid "Register BookTextBlock as linkable in TinyMCE."
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:185
+msgid "Register new 'Add Chapter' permission."
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:138
+msgid "Register new keywords tab."
 msgstr ""
 
 #: ./ftw/book/profiles/default/types/Remark.xml
@@ -136,6 +164,10 @@ msgstr ""
 msgid "This option inserts a column break when two column layout is active."
 msgstr ""
 
+#: ./ftw/book/configure.zcml:54
+msgid "Uninstall ftw.book"
+msgstr ""
+
 #: ./ftw/book/browser/table_export_import.py:93
 msgid "You didn't choose a column."
 msgstr ""
@@ -159,23 +191,23 @@ msgid "book_help_titlepage_logo_width"
 msgstr ""
 
 #. Default: "When enabled, a keyword index will be included in the PDF."
-#: ./ftw/book/content/book.py:79
+#: ./ftw/book/content/book.py:88
 msgid "book_help_use_index"
 msgstr ""
 
-#: ./ftw/book/content/book.py:69
+#: ./ftw/book/content/book.py:78
 msgid "book_help_use_loi"
 msgstr ""
 
-#: ./ftw/book/content/book.py:59
+#: ./ftw/book/content/book.py:68
 msgid "book_help_use_lot"
 msgstr ""
 
-#: ./ftw/book/content/book.py:39
+#: ./ftw/book/content/book.py:48
 msgid "book_help_use_titlepage"
 msgstr ""
 
-#: ./ftw/book/content/book.py:49
+#: ./ftw/book/content/book.py:58
 msgid "book_help_use_toc"
 msgstr ""
 
@@ -190,7 +222,7 @@ msgid "book_label_author_address"
 msgstr ""
 
 #. Default: "Layout"
-#: ./ftw/book/content/book.py:29
+#: ./ftw/book/content/book.py:38
 msgid "book_label_layout"
 msgstr ""
 
@@ -210,27 +242,27 @@ msgid "book_label_titlepage_logo_width"
 msgstr ""
 
 #. Default: "Embedd subject index"
-#: ./ftw/book/content/book.py:77
+#: ./ftw/book/content/book.py:86
 msgid "book_label_use_index"
 msgstr ""
 
 #. Default: "Embedd list of illustrations"
-#: ./ftw/book/content/book.py:67
+#: ./ftw/book/content/book.py:76
 msgid "book_label_use_loi"
 msgstr ""
 
 #. Default: "Embedd list of tables."
-#: ./ftw/book/content/book.py:57
+#: ./ftw/book/content/book.py:66
 msgid "book_label_use_lot"
 msgstr ""
 
 #. Default: "Embedd a title page"
-#: ./ftw/book/content/book.py:37
+#: ./ftw/book/content/book.py:46
 msgid "book_label_use_titlepage"
 msgstr ""
 
 #. Default: "Embedd table of contents"
-#: ./ftw/book/content/book.py:47
+#: ./ftw/book/content/book.py:56
 msgid "book_label_use_toc"
 msgstr ""
 
@@ -269,6 +301,34 @@ msgstr ""
 #: ./ftw/book/content/table.py:220
 msgid "description_no_lifting"
 msgstr ""
+
+#: ./ftw/book/configure.zcml:40
+msgid "ftw.book"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:33
+msgid "ftw.book.upgrades.2200"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:63
+msgid "ftw.book.upgrades.2300"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:82
+msgid "ftw.book.upgrades.2301"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:101
+msgid "ftw.book.upgrades.3000"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:129
+msgid "ftw.book.upgrades.3002"
+msgstr ""
+
+#: ./ftw/book/content/book.py:28
+msgid "help_web_toc_depth"
+msgstr "How many chapters should be included before the toc tree stops. 0 means no limit. This has no effect on the PDF."
 
 #. Default: "Please activate the required columns under 'Layout' and and save the object."
 #: ./ftw/book/skins/ftw_book_templates/datagridwidget_bibliothek_table.pt:60
@@ -410,8 +470,13 @@ msgstr ""
 msgid "label_table_content"
 msgstr ""
 
+#. Default: "Table of contents depth"
+#: ./ftw/book/content/book.py:26
+msgid "label_web_toc_depth"
+msgstr ""
+
 #. Default: "See page ${pageref}"
-#: ./ftw/book/latex/hyperlink_subconverter.py:31
+#: ./ftw/book/latex/hyperlink_subconverter.py:32
 msgid "latex_page_reference"
 msgstr ""
 
@@ -529,5 +594,4 @@ msgstr ""
 #: ./ftw/book/latex/defaultlayout.py:215
 msgid "title_index"
 msgstr ""
-
 

--- a/ftw/book/locales/en/LC_MESSAGES/ftw.tabbedview.po
+++ b/ftw/book/locales/en/LC_MESSAGES/ftw.tabbedview.po
@@ -26,4 +26,3 @@ msgstr "Table Of Contents"
 msgid "keywords"
 msgstr "Keywords"
 
-

--- a/ftw/book/locales/en/LC_MESSAGES/plone.po
+++ b/ftw/book/locales/en/LC_MESSAGES/plone.po
@@ -20,4 +20,3 @@ msgstr "Table of contents"
 msgid "tabbed_view"
 msgstr "Tabbed view"
 
-

--- a/ftw/book/locales/fr/LC_MESSAGES/ftw.book.po
+++ b/ftw/book/locales/fr/LC_MESSAGES/ftw.book.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-06-11 11:58+0000\n"
+"POT-Creation-Date: 2016-04-28 07:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,6 +47,10 @@ msgstr "2 mm font gris"
 msgid "2mm indent"
 msgstr "2 mm en recul"
 
+#: ./ftw/book/upgrades/configure.zcml:203
+msgid "Add footnote plugin."
+msgstr ""
+
 #: ./ftw/book/content/table.py:289
 msgid "Bold"
 msgstr "Gras"
@@ -58,6 +62,10 @@ msgstr "Livre"
 #: ./ftw/book/profiles/default/types/BookTextBlock.xml
 #: ./ftw/book/upgrades/profiles/3000/types/BookTextBlock.xml
 msgid "BookTextBlock"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:194
+msgid "Change HTMLBlock icon."
 msgstr ""
 
 #: ./ftw/book/profiles/default/types/Chapter.xml
@@ -96,6 +104,14 @@ msgstr "Bloc HTML"
 msgid "Import"
 msgstr "Importer"
 
+#: ./ftw/book/upgrades/configure.zcml:156
+msgid "Install ftw.contentpage and make ListingBlock available in books"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:110
+msgid "Install tinymce keyword plugin"
+msgstr ""
+
 #: ./ftw/book/content/table.py:288
 msgid "Normal"
 msgstr "Normal"
@@ -103,6 +119,18 @@ msgstr "Normal"
 #: ./ftw/book/profiles/default/actions.xml
 msgid "PDF"
 msgstr "PDF"
+
+#: ./ftw/book/upgrades/configure.zcml:147
+msgid "Register BookTextBlock as linkable in TinyMCE."
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:185
+msgid "Register new 'Add Chapter' permission."
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:138
+msgid "Register new keywords tab."
+msgstr ""
 
 #: ./ftw/book/profiles/default/types/Remark.xml
 msgid "Remark"
@@ -136,6 +164,10 @@ msgstr "Ce tableau n'a pas encore de contenu. Il faut éiter le tableau pour int
 msgid "This option inserts a column break when two column layout is active."
 msgstr "Cette option intègre une colonne d'espacement quand la mise en page deux colonnes est active"
 
+#: ./ftw/book/configure.zcml:54
+msgid "Uninstall ftw.book"
+msgstr ""
+
 #: ./ftw/book/browser/table_export_import.py:93
 msgid "You didn't choose a column."
 msgstr "Vous n'avez pas choisi de colonne"
@@ -159,23 +191,23 @@ msgid "book_help_titlepage_logo_width"
 msgstr "Largeur du logo adapté selon la largeur de page à disposition"
 
 #. Default: "When enabled, a keyword index will be included in the PDF."
-#: ./ftw/book/content/book.py:79
+#: ./ftw/book/content/book.py:88
 msgid "book_help_use_index"
 msgstr ""
 
-#: ./ftw/book/content/book.py:69
+#: ./ftw/book/content/book.py:78
 msgid "book_help_use_loi"
 msgstr "Si cette option est choissie, un registre d'affichage sera créé"
 
-#: ./ftw/book/content/book.py:59
+#: ./ftw/book/content/book.py:68
 msgid "book_help_use_lot"
 msgstr "Si cette option est choissie, un registre de tableau sera créé"
 
-#: ./ftw/book/content/book.py:39
+#: ./ftw/book/content/book.py:48
 msgid "book_help_use_titlepage"
 msgstr "Si cette option est choissie, une page d'en-tête sera créée"
 
-#: ./ftw/book/content/book.py:49
+#: ./ftw/book/content/book.py:58
 msgid "book_help_use_toc"
 msgstr "Si cette option est choissie, une table des matières sera créée"
 
@@ -190,7 +222,7 @@ msgid "book_label_author_address"
 msgstr "Adresse de l'auteur"
 
 #. Default: "Layout"
-#: ./ftw/book/content/book.py:29
+#: ./ftw/book/content/book.py:38
 msgid "book_label_layout"
 msgstr "Layout"
 
@@ -210,27 +242,27 @@ msgid "book_label_titlepage_logo_width"
 msgstr "Taille du logo de la page d'en-tête"
 
 #. Default: "Embedd subject index"
-#: ./ftw/book/content/book.py:77
+#: ./ftw/book/content/book.py:86
 msgid "book_label_use_index"
 msgstr ""
 
 #. Default: "Embedd list of illustrations"
-#: ./ftw/book/content/book.py:67
+#: ./ftw/book/content/book.py:76
 msgid "book_label_use_loi"
 msgstr "Lier liste des illustrations"
 
 #. Default: "Embedd list of tables."
-#: ./ftw/book/content/book.py:57
+#: ./ftw/book/content/book.py:66
 msgid "book_label_use_lot"
 msgstr "Lier liste des tableaux"
 
 #. Default: "Embedd a title page"
-#: ./ftw/book/content/book.py:37
+#: ./ftw/book/content/book.py:46
 msgid "book_label_use_titlepage"
 msgstr "Lier page d'en-tête"
 
 #. Default: "Embedd table of contents"
-#: ./ftw/book/content/book.py:47
+#: ./ftw/book/content/book.py:56
 msgid "book_label_use_toc"
 msgstr "Lier tableau du contenu"
 
@@ -269,6 +301,34 @@ msgstr "Ajouter de nouvelles lignes"
 #: ./ftw/book/content/table.py:220
 msgid "description_no_lifting"
 msgstr "En exportant un livre au format PDF avec la première cellule vide, tout le tableau se déplace d'une ligne vers le haut. Ainsi, le titre de la table est affiché sur la même hauteur que la première ligne du tableau. Pour supprimer ce problème, activez cette option."
+
+#: ./ftw/book/configure.zcml:40
+msgid "ftw.book"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:33
+msgid "ftw.book.upgrades.2200"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:63
+msgid "ftw.book.upgrades.2300"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:82
+msgid "ftw.book.upgrades.2301"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:101
+msgid "ftw.book.upgrades.3000"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:129
+msgid "ftw.book.upgrades.3002"
+msgstr ""
+
+#: ./ftw/book/content/book.py:28
+msgid "help_web_toc_depth"
+msgstr "La profondeur maximale de l'arbre contenu. 0 signifie pas de limite. Cela n'a aucune incidence sur le PDF."
 
 #. Default: "Please activate the required columns under 'Layout' and and save the object."
 #: ./ftw/book/skins/ftw_book_templates/datagridwidget_bibliothek_table.pt:60
@@ -410,8 +470,13 @@ msgstr "Montrer le titre"
 msgid "label_table_content"
 msgstr "Contenu du tableau"
 
+#. Default: "Table of contents depth"
+#: ./ftw/book/content/book.py:26
+msgid "label_web_toc_depth"
+msgstr "Profondeur de l'arbre de contenu"
+
 #. Default: "See page ${pageref}"
-#: ./ftw/book/latex/hyperlink_subconverter.py:31
+#: ./ftw/book/latex/hyperlink_subconverter.py:32
 msgid "latex_page_reference"
 msgstr ""
 
@@ -529,5 +594,4 @@ msgstr "Importer/exporter les données du tableau"
 #: ./ftw/book/latex/defaultlayout.py:215
 msgid "title_index"
 msgstr ""
-
 

--- a/ftw/book/locales/fr/LC_MESSAGES/plone.po
+++ b/ftw/book/locales/fr/LC_MESSAGES/plone.po
@@ -20,4 +20,3 @@ msgstr "Table des matières"
 msgid "tabbed_view"
 msgstr "Onglet"
 
-

--- a/ftw/book/locales/ftw.book.pot
+++ b/ftw/book/locales/ftw.book.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-06-11 11:58+0000\n"
+"POT-Creation-Date: 2016-04-28 07:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,6 +50,10 @@ msgstr ""
 msgid "2mm indent"
 msgstr ""
 
+#: ./ftw/book/upgrades/configure.zcml:203
+msgid "Add footnote plugin."
+msgstr ""
+
 #: ./ftw/book/content/table.py:289
 msgid "Bold"
 msgstr ""
@@ -61,6 +65,10 @@ msgstr ""
 #: ./ftw/book/profiles/default/types/BookTextBlock.xml
 #: ./ftw/book/upgrades/profiles/3000/types/BookTextBlock.xml
 msgid "BookTextBlock"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:194
+msgid "Change HTMLBlock icon."
 msgstr ""
 
 #: ./ftw/book/profiles/default/types/Chapter.xml
@@ -99,12 +107,32 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
+#: ./ftw/book/upgrades/configure.zcml:156
+msgid "Install ftw.contentpage and make ListingBlock available in books"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:110
+msgid "Install tinymce keyword plugin"
+msgstr ""
+
 #: ./ftw/book/content/table.py:288
 msgid "Normal"
 msgstr ""
 
 #: ./ftw/book/profiles/default/actions.xml
 msgid "PDF"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:147
+msgid "Register BookTextBlock as linkable in TinyMCE."
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:185
+msgid "Register new 'Add Chapter' permission."
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:138
+msgid "Register new keywords tab."
 msgstr ""
 
 #: ./ftw/book/profiles/default/types/Remark.xml
@@ -139,6 +167,10 @@ msgstr ""
 msgid "This option inserts a column break when two column layout is active."
 msgstr ""
 
+#: ./ftw/book/configure.zcml:54
+msgid "Uninstall ftw.book"
+msgstr ""
+
 #: ./ftw/book/browser/table_export_import.py:93
 msgid "You didn't choose a column."
 msgstr ""
@@ -162,23 +194,23 @@ msgid "book_help_titlepage_logo_width"
 msgstr ""
 
 #. Default: "When enabled, a keyword index will be included in the PDF."
-#: ./ftw/book/content/book.py:79
+#: ./ftw/book/content/book.py:88
 msgid "book_help_use_index"
 msgstr ""
 
-#: ./ftw/book/content/book.py:69
+#: ./ftw/book/content/book.py:78
 msgid "book_help_use_loi"
 msgstr ""
 
-#: ./ftw/book/content/book.py:59
+#: ./ftw/book/content/book.py:68
 msgid "book_help_use_lot"
 msgstr ""
 
-#: ./ftw/book/content/book.py:39
+#: ./ftw/book/content/book.py:48
 msgid "book_help_use_titlepage"
 msgstr ""
 
-#: ./ftw/book/content/book.py:49
+#: ./ftw/book/content/book.py:58
 msgid "book_help_use_toc"
 msgstr ""
 
@@ -193,7 +225,7 @@ msgid "book_label_author_address"
 msgstr ""
 
 #. Default: "Layout"
-#: ./ftw/book/content/book.py:29
+#: ./ftw/book/content/book.py:38
 msgid "book_label_layout"
 msgstr ""
 
@@ -213,27 +245,27 @@ msgid "book_label_titlepage_logo_width"
 msgstr ""
 
 #. Default: "Embedd subject index"
-#: ./ftw/book/content/book.py:77
+#: ./ftw/book/content/book.py:86
 msgid "book_label_use_index"
 msgstr ""
 
 #. Default: "Embedd list of illustrations"
-#: ./ftw/book/content/book.py:67
+#: ./ftw/book/content/book.py:76
 msgid "book_label_use_loi"
 msgstr ""
 
 #. Default: "Embedd list of tables."
-#: ./ftw/book/content/book.py:57
+#: ./ftw/book/content/book.py:66
 msgid "book_label_use_lot"
 msgstr ""
 
 #. Default: "Embedd a title page"
-#: ./ftw/book/content/book.py:37
+#: ./ftw/book/content/book.py:46
 msgid "book_label_use_titlepage"
 msgstr ""
 
 #. Default: "Embedd table of contents"
-#: ./ftw/book/content/book.py:47
+#: ./ftw/book/content/book.py:56
 msgid "book_label_use_toc"
 msgstr ""
 
@@ -271,6 +303,34 @@ msgstr ""
 #. Default: "When exporting the book as PDF the table will be pulled up if there is no content in the first cell. The aim is to place a preceding title at the same height as the first row of the table. For suppressing this behaviour enable this option."
 #: ./ftw/book/content/table.py:220
 msgid "description_no_lifting"
+msgstr ""
+
+#: ./ftw/book/configure.zcml:40
+msgid "ftw.book"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:33
+msgid "ftw.book.upgrades.2200"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:63
+msgid "ftw.book.upgrades.2300"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:82
+msgid "ftw.book.upgrades.2301"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:101
+msgid "ftw.book.upgrades.3000"
+msgstr ""
+
+#: ./ftw/book/upgrades/configure.zcml:129
+msgid "ftw.book.upgrades.3002"
+msgstr ""
+
+#: ./ftw/book/content/book.py:28
+msgid "help_web_toc_depth"
 msgstr ""
 
 #. Default: "Please activate the required columns under 'Layout' and and save the object."
@@ -413,8 +473,13 @@ msgstr ""
 msgid "label_table_content"
 msgstr ""
 
+#. Default: "Table of contents depth"
+#: ./ftw/book/content/book.py:26
+msgid "label_web_toc_depth"
+msgstr ""
+
 #. Default: "See page ${pageref}"
-#: ./ftw/book/latex/hyperlink_subconverter.py:31
+#: ./ftw/book/latex/hyperlink_subconverter.py:32
 msgid "latex_page_reference"
 msgstr ""
 
@@ -532,5 +597,4 @@ msgstr ""
 #: ./ftw/book/latex/defaultlayout.py:215
 msgid "title_index"
 msgstr ""
-
 

--- a/ftw/book/tests/test_toc_view.py
+++ b/ftw/book/tests/test_toc_view.py
@@ -1,0 +1,57 @@
+from ftw.book.testing import FTW_BOOK_FUNCTIONAL_TESTING
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browser
+from ftw.testbrowser import browsing
+from unittest2 import TestCase
+
+
+class TestTOCView(TestCase):
+
+    layer = FTW_BOOK_FUNCTIONAL_TESTING
+
+    @browsing
+    def test_toc_depth_config(self, browser):
+        book = create(Builder('book').titled('The Book'))
+        chapter = create(Builder('chapter')
+                         .titled('First Chapter')
+                         .within(book))
+        subchapter = create(Builder('chapter')
+                            .titled('The SubChapter')
+                            .within(chapter))
+        create(Builder('chapter')
+               .titled('The SubSubChapter')
+               .within(subchapter))
+
+        browser.login().visit(book)
+
+        # view shows all subchapters by default
+        self.assertEquals(
+            ['The Book', '1 First Chapter',
+                '1.1 The SubChapter', '1.1.1 The SubSubChapter'],
+            [e.text for e in browser.css('#content-core .navTreeItem a')])
+
+        # limit depth to 1 subchapter
+        browser.open(book, view='edit')
+        browser.fill({'Table of contents depth': '1'}).submit()
+
+        self.assertEquals(
+            ['The Book', '1 First Chapter'],
+            [e.text for e in browser.css('#content-core .navTreeItem a')])
+
+        # limit depth to 2 subchapter
+        browser.open(book, view='edit')
+        browser.fill({'Table of contents depth': '2'}).submit()
+
+        self.assertEquals(
+            ['The Book', '1 First Chapter', '1.1 The SubChapter'],
+            [e.text for e in browser.css('#content-core .navTreeItem a')])
+
+        # empty depth means no limit
+        browser.open(book, view='edit')
+        browser.fill({'Table of contents depth': ''}).submit()
+
+        self.assertEquals(
+            ['The Book', '1 First Chapter',
+                '1.1 The SubChapter', '1.1.1 The SubSubChapter'],
+            [e.text for e in browser.css('#content-core .navTreeItem a')])


### PR DESCRIPTION
This PR allows the user to configure how many levels of the toc should be displayed on the web.
This is useful if someone has a huge book where the full toc would have hundreds of entries.

Default value is 0 (no limitation) which means there is no change for upgrading users.

**No limitation:**
![screen shot 2016-04-28 at 10 16 45](https://cloud.githubusercontent.com/assets/1375745/14879583/57eaa170-0d2a-11e6-8f7f-500cc83fc083.png)
**Configure limit:**
![screen shot 2016-04-28 at 10 11 54](https://cloud.githubusercontent.com/assets/1375745/14879564/3ecdfb56-0d2a-11e6-87f9-0f081caacfd8.png)
**Limited toc:**
![screen shot 2016-04-28 at 10 12 06](https://cloud.githubusercontent.com/assets/1375745/14879568/422b3ad4-0d2a-11e6-990e-830cbc4081a1.png)
