### PR TITLE
Disable PDF tests since they are brittle.

### DIFF
--- a/ftw/book/tests/test_book_export.py
+++ b/ftw/book/tests/test_book_export.py
@@ -1,9 +1,11 @@
 from ftw.book.testing import EXAMPLE_CONTENT_INTEGRATION_TESTING
+import unittest2
 from ftw.book.tests.base import PDFDiffTestCase
 import os
 
 
 if not os.environ.get('SKIP_BOOK_EXPORTS', False):
+    @unittest2.skip('PDF tests are currently flaky.')
     class TestPDFExport(PDFDiffTestCase):
 
         layer = EXAMPLE_CONTENT_INTEGRATION_TESTING


### PR DESCRIPTION
On our new jenkins server, the PDF generation is not exactly the same
all the time. That means we cannot make it always pass that easily.
Therefore I'm disabling the test because we have no benefit of it.

The test code is kept because it may help when developing locally.