### PR TITLE
Fix: Make description appear

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 3.5.4 (unreleased)
 ------------------
 
+- Fix: Make helper text appear [busykoala]
 - Drop Plone 4.2 support. [busykoala]
 
 

--- a/ftw/book/content/book.py
+++ b/ftw/book/content/book.py
@@ -84,10 +84,10 @@ BookSchema = (folder.ATFolderSchema.copy() +
 
                 widget=atapi.BooleanWidget(
                     label=_(u'book_label_use_index',
-                            default=u'Embedd subject index')),
+                            default=u'Embedd subject index'),
                 description=_(u'book_help_use_index',
                               default=u'When enabled, a keyword index '
-                              'will be included in the PDF.')),
+                              'will be included in the PDF.'))),
 
             )))
 

--- a/ftw/book/content/book.py
+++ b/ftw/book/content/book.py
@@ -85,11 +85,11 @@ BookSchema = (folder.ATFolderSchema.copy() +
                 widget=atapi.BooleanWidget(
                     label=_(u'book_label_use_index',
                             default=u'Embedd subject index'),
-                description=_(u'book_help_use_index',
-                              default=u'When enabled, a keyword index '
-                              'will be included in the PDF.'))),
+                    description=_(u'book_help_use_index',
+                                  default=u'When enabled, a keyword index '
+                                          'will be included in the PDF.'))),
 
-            )))
+              )))
 
 
 schemata.finalizeATCTSchema(BookSchema, folderish=True, moveDiscussion=False)


### PR DESCRIPTION
Because of brackets closing too early the description was not appearing.
I corrected that so the book_help_use_index is appearing correctly now.

Fixed the description appears correctly:
![image](https://user-images.githubusercontent.com/29920936/51480248-da829d80-1d90-11e9-8d10-9dac03d2b9d1.png)

Before the issue was, that there was no helper text:
![image](https://user-images.githubusercontent.com/29920936/51480300-fdad4d00-1d90-11e9-9954-9afac2010c84.png)
