### PR TITLE
Add missing dependency collective.transmogrifier.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ maintainer = 'Jonas Baumann'
 
 tests_require = [
     'Products.GenericSetup',
+    'collective.transmogrifier',
     'ftw.builder',
     'ftw.contentpage [tests]',
     'ftw.inflator',


### PR DESCRIPTION
collective.transmogrifier is used in `testing.py`. Therefore we should add it as a test dependency.