### PR TITLE
Fix the title translation of chapters.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Fix navigation and search settings for new DX types. [jone]
+- Fix chapter's title translation. [jone]
 
 
 4.0.1 (2019-11-04)

--- a/ftw/book/contents/chapter.py
+++ b/ftw/book/contents/chapter.py
@@ -1,21 +1,18 @@
+from ftw.book import _
 from ftw.book.interfaces import IChapter
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.supermodel.model import Schema
-from zope.i18nmessageid import MessageFactory
 from zope.interface import implements
 from zope.interface import provider
 from zope.schema import TextLine
-
-
-DXMF = MessageFactory('plone.app.dexterity')
 
 
 @provider(IFormFieldProvider)
 class IChapterSchema(Schema):
 
     title = TextLine(
-        title=DXMF(u'label_title', default=u'Title'),
+        title=_(u'label_title', default=u'Title'),
         required=True,
     )
 

--- a/ftw/book/locales/de/LC_MESSAGES/ftw.book.po
+++ b/ftw/book/locales/de/LC_MESSAGES/ftw.book.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
-"POT-Creation-Date: 2019-11-01 14:33+0000\n"
+"POT-Creation-Date: 2019-11-05 13:06+0000\n"
 "PO-Revision-Date: 2012-11-14 14:46+0100\n"
 "Last-Translator: Julian Infanger <julian.infanger@4teamwork.ch>\n"
 "Language-Team: Julian Infanger <julian.infanger@4teamwork.ch>\n"
@@ -411,6 +411,7 @@ msgid "label_table_export_import"
 msgstr "Tabelle exportieren / importieren"
 
 #. Default: "Title"
+#: ./ftw/book/contents/chapter.py:15
 #: ./ftw/book/contents/table.py:174
 msgid "label_title"
 msgstr "Titel"

--- a/ftw/book/locales/en/LC_MESSAGES/ftw.book.po
+++ b/ftw/book/locales/en/LC_MESSAGES/ftw.book.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-01 14:33+0000\n"
+"POT-Creation-Date: 2019-11-05 13:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -408,6 +408,7 @@ msgid "label_table_export_import"
 msgstr ""
 
 #. Default: "Title"
+#: ./ftw/book/contents/chapter.py:15
 #: ./ftw/book/contents/table.py:174
 msgid "label_title"
 msgstr ""

--- a/ftw/book/locales/fr/LC_MESSAGES/ftw.book.po
+++ b/ftw/book/locales/fr/LC_MESSAGES/ftw.book.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-01 14:33+0000\n"
+"POT-Creation-Date: 2019-11-05 13:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -408,6 +408,7 @@ msgid "label_table_export_import"
 msgstr ""
 
 #. Default: "Title"
+#: ./ftw/book/contents/chapter.py:15
 #: ./ftw/book/contents/table.py:174
 msgid "label_title"
 msgstr ""

--- a/ftw/book/locales/ftw.book.pot
+++ b/ftw/book/locales/ftw.book.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-01 14:33+0000\n"
+"POT-Creation-Date: 2019-11-05 13:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -411,6 +411,7 @@ msgid "label_table_export_import"
 msgstr ""
 
 #. Default: "Title"
+#: ./ftw/book/contents/chapter.py:15
 #: ./ftw/book/contents/table.py:174
 msgid "label_title"
 msgstr ""


### PR DESCRIPTION
The label of the title field of chapters used the wrong translation domain. We are no using the ftw.book domain for this label.