### PR TITLE
Fix navigation and search settings for new DX types.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix navigation and search settings for new DX types. [jone]
 
 
 4.0.1 (2019-11-04)

--- a/ftw/book/upgrades/20191105142404_fix_navigation_and_search_for_new_types/propertiestool.xml
+++ b/ftw/book/upgrades/20191105142404_fix_navigation_and_search_for_new_types/propertiestool.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+    <object name="navtree_properties" meta_type="Plone Property Sheet">
+
+        <property name="metaTypesNotToList" type="lines" purge="False">
+            <element value="ftw.book.FileListingBlock"/>
+            <element value="ftw.book.HtmlBlock"/>
+            <element value="ftw.book.Table"/>
+            <element value="ftw.book.TextBlock"/>
+        </property>
+
+    </object>
+
+    <object name="site_properties" meta_type="Plone Property Sheet">
+
+        <property name="types_not_searched" type="lines" purge="False">
+            <element value="ftw.book.FileListingBlock"/>
+            <element value="ftw.book.HtmlBlock"/>
+            <element value="ftw.book.Table"/>
+            <element value="ftw.book.TextBlock"/>
+        </property>
+
+    </object>
+
+</object>

--- a/ftw/book/upgrades/20191105142404_fix_navigation_and_search_for_new_types/upgrade.py
+++ b/ftw/book/upgrades/20191105142404_fix_navigation_and_search_for_new_types/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixNavigationAndSearchForNewTypes(UpgradeStep):
+    """Fix navigation and search for new types.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The property settings were not updated correctly when the new DX types were introduced, resulting in wrong incomplete settings for navigation and search when the book was migrated through upgrade steps. This upgrade step imports the new settings.

See https://github.com/4teamwork/ftw.book/pull/100