### PR TITLE
Remove "Type" column from listing block table in PDF.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 4.0.2 (unreleased)
 ------------------
 
+- Remove "Type" column from listing block table in PDF. [jone]
 - Fix navigation and search settings for new DX types. [jone]
 - Fix chapter's title translation. [jone]
 

--- a/ftw/book/browser/blockview.py
+++ b/ftw/book/browser/blockview.py
@@ -79,7 +79,16 @@ class BookTextBlockView(BookBlockMixin, TextBlockView):
 
 
 class BookFileListingBlockView(BookBlockMixin, FileListingBlockView):
-    pass
+
+    def render_table(self, ignore_columns=()):
+        self.ignored_columns = ignore_columns
+        return super(BookFileListingBlockView, self).render_table()
+
+    def _filtered_columns(self):
+        columns = super(BookFileListingBlockView, self)._filtered_columns()
+        for column in columns:
+            if column['column'] not in self.ignored_columns:
+                yield column
 
 
 class HTMLBlockView(BookBlockMixin, HtmlBlockView):

--- a/ftw/book/latex/listingblock.py
+++ b/ftw/book/latex/listingblock.py
@@ -75,7 +75,7 @@ class ListingBlockLaTeXView(MakoLaTeXView):
 
     def table_latex(self):
         view = self.context.restrictedTraverse('block_view')
-        table_html = view.render_table()
+        table_html = view.render_table(ignore_columns=('getContentType',))
         table_html = remove_html_links(table_html)
         table_html = remove_table_summary(table_html)
         table_html = remove_table_caption(table_html)

--- a/ftw/book/tests/test_latex_view_listingblock.py
+++ b/ftw/book/tests/test_latex_view_listingblock.py
@@ -18,15 +18,15 @@ class TestListingBlockLaTeXView(FunctionalTestCase):
 
 \makeatletter\@ifundefined{tablewidth}{\newlength\tablewidth}\makeatother
 \setlength\tablewidth\linewidth
-\addtolength\tablewidth{-6\tabcolsep}
+\addtolength\tablewidth{-4\tabcolsep}
 \renewcommand{\arraystretch}{1.4}
-\begin{tabular}{p{0.44\tablewidth}p{0.44\tablewidth}p{0.12\tablewidth}}
+\begin{tabular}{p{0.88\tablewidth}p{0.12\tablewidth}}
 \hline
-\multicolumn{1}{p{0.44\tablewidth}}{\textbf{Type}} & \multicolumn{1}{p{0.44\tablewidth}}{\textbf{Title}} & \multicolumn{1}{p{0.12\tablewidth}}{\textbf{modified}} \\
+\multicolumn{1}{p{0.88\tablewidth}}{\textbf{Title}} & \multicolumn{1}{p{0.12\tablewidth}}{\textbf{modified}} \\
 \hline
-\multicolumn{1}{p{0.44\tablewidth}}{} & \multicolumn{1}{p{0.44\tablewidth}}{Einfache Webseite} & \multicolumn{1}{p{0.12\tablewidth}}{31.10.2016} \\
+\multicolumn{1}{p{0.88\tablewidth}}{Einfache Webseite} & \multicolumn{1}{p{0.12\tablewidth}}{31.10.2016} \\
 \hline
-\multicolumn{1}{p{0.44\tablewidth}}{} & \multicolumn{1}{p{0.44\tablewidth}}{Fröhliches Bild} & \multicolumn{1}{p{0.12\tablewidth}}{31.10.2016} \\
+\multicolumn{1}{p{0.88\tablewidth}}{Fröhliches Bild} & \multicolumn{1}{p{0.12\tablewidth}}{31.10.2016} \\
 \hline
 \end{tabular}\\
 \vspace{4pt}
@@ -45,7 +45,7 @@ class TestListingBlockLaTeXView(FunctionalTestCase):
 -
  \makeatletter\@ifundefined{tablewidth}{\newlength\tablewidth}\makeatother
  \setlength\tablewidth\linewidth
- \addtolength\tablewidth{-6\tabcolsep}
+ \addtolength\tablewidth{-4\tabcolsep}
                 '''):
             self.listingblock.show_title = False
 


### PR DESCRIPTION
The type column shows an icon of the mimetype of the file in the web. But we do not have those icons (font awesome) in the PDF, so the column is always empty. Therefore we just remove the column from the PDF.

Before:
<img width="785" alt="Bildschirmfoto 2019-11-06 um 14 38 52" src="https://user-images.githubusercontent.com/7469/68302923-2e9e0a80-00a3-11ea-9083-0b026297b7c3.png">
After:
<img width="756" alt="Bildschirmfoto 2019-11-06 um 14 38 56" src="https://user-images.githubusercontent.com/7469/68302929-3198fb00-00a3-11ea-8913-38610066eaa5.png">
