### PR TITLE
Always use h2 heading chapter content and make chapter block more compact

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 4.0.2 (unreleased)
 ------------------
 
+- Always use h2 heading chapter content and make chapter block more compact. [jone]
 - PDF: use external links for non-PDF content. [jone]
 - Remove "Type" column from listing block table in PDF. [jone]
 - Fix navigation and search settings for new DX types. [jone]

--- a/ftw/book/browser/blockview.py
+++ b/ftw/book/browser/blockview.py
@@ -21,6 +21,7 @@ class BookBlockMixin:
         return TableOfContents().html_heading(
             self.context,
             linked=False,
+            tagname='h2',
             prepend_html_headings=self.prepend_html_headings)
 
     def has_tables_with_missing_widths(self):
@@ -69,6 +70,7 @@ class BookChapterView(BrowserView):
     def block_title(self):
         return TableOfContents().html_heading(
             self.context,
+            tagname='h2',
             linked=True,
             prepend_html_headings=self.prepend_html_headings)
 

--- a/ftw/book/browser/resources/theming.scss
+++ b/ftw/book/browser/resources/theming.scss
@@ -34,6 +34,14 @@ ul.book-index {
 }
 
 
+body .sl-simplelayout.sl-can-edit .sl-block.ftw-book-chapter {
+  min-height: 0;
+}
+.sl-block.ftw-book-chapter h2 {
+  margin: .5em 0;
+}
+
+
 /* let chapter be addable although its a sl block
 https://github.com/4teamwork/ftw.simplelayout/blob/master/ftw/simplelayout/browser/dynamic_scss_resources.py */
 body #plone-contentmenu-factories .contenttype-ftw-book-chapter {

--- a/ftw/book/tests/test_fti_chapter.py
+++ b/ftw/book/tests/test_fti_chapter.py
@@ -26,9 +26,9 @@ class TestChapter(FunctionalTestCase):
 
         browser.login().visit(chapter)
         self.assertIn(
-            u'<h3 class="toc3"><a href="{}">China</a></h3>'.format(
+            u'<h2 class="toc3"><a href="{}">China</a></h2>'.format(
                 subchapter.absolute_url()),
-            map(attrgetter('outerHTML'), browser.css('.sl-block h3')))
+            map(attrgetter('outerHTML'), browser.css('.sl-block h2')))
 
         browser.css('#content-core').first.find('China').click()
         self.assertEquals(subchapter, browser.context)

--- a/ftw/book/tests/test_fti_htmlblock.py
+++ b/ftw/book/tests/test_fti_htmlblock.py
@@ -29,8 +29,8 @@ class TestHTMLBlock(FunctionalTestCase):
                           'Expected chapter to have exactly one block')
 
         self.assertEquals(
-            u'<h3 class="toc3">The HTML Block</h3>',
-            browser.css('.sl-block h3').first.outerHTML)
+            u'<h2 class="toc3">The HTML Block</h2>',
+            browser.css('.sl-block h2').first.outerHTML)
 
         self.assertEquals(
             'Some <b>body</b> text',
@@ -44,12 +44,12 @@ class TestHTMLBlock(FunctionalTestCase):
         self.htmlblock.show_title = False
         transaction.commit()
         browser.login().visit(self.htmlblock)
-        self.assertNotIn(title, browser.css('.sl-block h3').text)
+        self.assertNotIn(title, browser.css('.sl-block h2').text)
 
         self.htmlblock.show_title = True
         transaction.commit()
         browser.reload()
-        self.assertIn(title, browser.css('.sl-block h3').text)
+        self.assertIn(title, browser.css('.sl-block h2').text)
 
     @browsing
     def test_no_prefix_when_hiding_title_from_table_of_contents(self, browser):
@@ -60,15 +60,15 @@ class TestHTMLBlock(FunctionalTestCase):
         transaction.commit()
         browser.login().visit(self.htmlblock)
         self.assertIn(
-            u'<h3 class="toc3">An HTML Block</h3>',
-            map(attrgetter('outerHTML'), browser.css('.sl-block h3')))
+            u'<h2 class="toc3">An HTML Block</h2>',
+            map(attrgetter('outerHTML'), browser.css('.sl-block h2')))
 
         self.htmlblock.hide_from_toc = True
         transaction.commit()
         browser.reload()
         self.assertIn(
-            u'<h3 class="no-toc">An HTML Block</h3>',
-            map(attrgetter('outerHTML'), browser.css('.sl-block h3')))
+            u'<h2 class="no-toc">An HTML Block</h2>',
+            map(attrgetter('outerHTML'), browser.css('.sl-block h2')))
 
     @browsing
     def test_warning_when_table_widths_not_specified(self, browser):

--- a/ftw/book/tests/test_fti_listingblock.py
+++ b/ftw/book/tests/test_fti_listingblock.py
@@ -28,13 +28,13 @@ class TestListingBlock(FunctionalTestCase):
                           'Expected chapter to have exactly one block')
 
         self.assertEquals(
-            u'<h3 class="toc3">Recipes</h3>',
-            browser.css('.sl-block h3').first.outerHTML)
+            u'<h2 class="toc3">Recipes</h2>',
+            browser.css('.sl-block h2').first.outerHTML)
 
     @browsing
     def test_showing_block_title(self, browser):
         title = 'Important Documents'
-        selector = '.sl-block h4'
+        selector = '.sl-block h2'
 
         self.grant('Manager')
         browser.login().visit(aq_parent(self.listingblock))
@@ -50,12 +50,12 @@ class TestListingBlock(FunctionalTestCase):
         self.grant('Manager')
         browser.login().visit(aq_parent(self.listingblock))
         self.assertIn(
-            u'<h4 class="toc4">Important Documents</h4>',
-            map(attrgetter('outerHTML'), browser.css('.sl-block h4')))
+            u'<h2 class="toc4">Important Documents</h2>',
+            map(attrgetter('outerHTML'), browser.css('.sl-block h2')))
 
         self.listingblock.hide_from_toc = True
         transaction.commit()
         browser.reload()
         self.assertIn(
-            u'<h4 class="no-toc">Important Documents</h4>',
-            map(attrgetter('outerHTML'), browser.css('.sl-block h4')))
+            u'<h2 class="no-toc">Important Documents</h2>',
+            map(attrgetter('outerHTML'), browser.css('.sl-block h2')))

--- a/ftw/book/tests/test_fti_textblock.py
+++ b/ftw/book/tests/test_fti_textblock.py
@@ -26,8 +26,8 @@ class TestTextBlock(FunctionalTestCase):
                           'Expected chapter to have exactly one block')
 
         self.assertEquals(
-            u'<h3 class="toc3">The Text Block</h3>',
-            browser.css('.sl-block h3').first.outerHTML)
+            u'<h2 class="toc3">The Text Block</h2>',
+            browser.css('.sl-block h2').first.outerHTML)
 
     @browsing
     def test_showing_block_title(self, browser):
@@ -37,12 +37,12 @@ class TestTextBlock(FunctionalTestCase):
         self.textblock.show_title = False
         transaction.commit()
         browser.login().visit(self.textblock)
-        self.assertNotIn(title, browser.css('.sl-block h4').text)
+        self.assertNotIn(title, browser.css('.sl-block h2').text)
 
         self.textblock.show_title = True
         transaction.commit()
         browser.reload()
-        self.assertIn(title, browser.css('.sl-block h4').text)
+        self.assertIn(title, browser.css('.sl-block h2').text)
 
     @browsing
     def test_hiding_title_from_table_of_contents_removes_prefix(self, browser):
@@ -53,15 +53,15 @@ class TestTextBlock(FunctionalTestCase):
         transaction.commit()
         browser.login().visit(self.textblock)
         self.assertIn(
-            u'<h4 class="toc4">First things first</h4>',
-            map(attrgetter('outerHTML'), browser.css('.sl-block h4')))
+            u'<h2 class="toc4">First things first</h2>',
+            map(attrgetter('outerHTML'), browser.css('.sl-block h2')))
 
         self.textblock.hide_from_toc = True
         transaction.commit()
         browser.reload()
         self.assertIn(
-            u'<h4 class="no-toc">First things first</h4>',
-            map(attrgetter('outerHTML'), browser.css('.sl-block h4')))
+            u'<h2 class="no-toc">First things first</h2>',
+            map(attrgetter('outerHTML'), browser.css('.sl-block h2')))
 
     @browsing
     def test_warning_when_table_widths_not_specified(self, browser):


### PR DESCRIPTION
- Make the block-title of a chapter (and textblocks) to be displayed as h2 in the chapter simplelayout view as this is semantically correct and looks consitent on all levels.

- Make the chapter block more compact for improved usability.

After:
<img width="1426" alt="Bildschirmfoto 2019-11-06 um 15 16 03" src="https://user-images.githubusercontent.com/7469/68390392-7edda100-0165-11ea-80c6-af8c550f8441.png">

Before:
<img width="1426" alt="Bildschirmfoto 2019-11-06 um 15 15 42" src="https://user-images.githubusercontent.com/7469/68390375-75eccf80-0165-11ea-94eb-12e14ca589f9.png">
