### PR TITLE
PDF: use external links for non-PDF content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 4.0.2 (unreleased)
 ------------------
 
+- PDF: use external links for non-PDF content. [jone]
 - Remove "Type" column from listing block table in PDF. [jone]
 - Fix navigation and search settings for new DX types. [jone]
 - Fix chapter's title translation. [jone]

--- a/ftw/book/tests/__init__.py
+++ b/ftw/book/tests/__init__.py
@@ -27,6 +27,8 @@ class FunctionalTestCase(TestCase):
             'introduction/an-html-block')
         self.listingblock = self.example_book.restrictedTraverse(
             'historical-background/china/important-documents')
+        self.lorem_file = self.listingblock.restrictedTraverse(
+            'lorem.html')
         self.table = self.example_book.unrestrictedTraverse(
             'historical-background/china/population')
         self.textblock = self.example_book.unrestrictedTraverse(


### PR DESCRIPTION
When a content is linked in a book and the target content is included in the same PDF, an PDF-internal reference is used. For external resources a URL-based link is used.

When linking files, which are stored in a listing block in the book, we still want to use an external URL-based link because files are not embedded in the PDF, so that file content is not part of the PDF.