### PR TITLE
Remove Referenceablebehavior.

### DIFF
--- a/ftw/book/browser/reader/renderer.py
+++ b/ftw/book/browser/reader/renderer.py
@@ -1,13 +1,13 @@
 from Acquisition import aq_chain
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from StringIO import StringIO
 from ftw.book.browser.reader.interfaces import IBookReaderRenderer
 from ftw.book.interfaces import IBook
 from ftw.simplelayout.interfaces import ISimplelayoutBlock
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from StringIO import StringIO
+from plone import api
 from zope.component import adapter
-from zope.interface import implementer
 from zope.interface import Interface
+from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserView
 import lxml.html
 
@@ -63,7 +63,7 @@ class DefaultBlockRenderer(BaseBookReaderRenderer):
         return lxml.html.tostring(doc)
 
     def get_uid_by_path(self, path):
-        catalog = getToolByName(self.context, 'portal_catalog')
+        catalog = api.portal.get_tool('portal_catalog')
         rid = catalog.getrid(path)
         if rid is None:
             return None
@@ -77,14 +77,11 @@ class DefaultBlockRenderer(BaseBookReaderRenderer):
 
         parts = url.split('/')
         if parts[-2] == 'resolveuid' or parts[-2] == 'resolveUid':
-            reference_catalog = getToolByName(self.context,
-                                              'reference_catalog')
-
-            uid = parts[-1]
-            obj = reference_catalog.lookupObject(uid)
+            portal_catalog = api.portal.get_tool('portal_catalog')
+            obj = portal_catalog.unrestrictedSearchResults(UID=parts[-1])
 
             if obj is not None:
-                url = obj.absolute_url()
+                url = obj[0].getURL()
         return url
 
 

--- a/ftw/book/testing.py
+++ b/ftw/book/testing.py
@@ -63,7 +63,6 @@ class BookLayer(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         if IS_PLONE_5:
             applyProfile(portal, 'plone.app.contenttypes:default')
-        applyProfile(portal, 'plone.app.referenceablebehavior:default')
         applyProfile(portal, 'ftw.tabbedview:default')
         applyProfile(portal, 'ftw.book:default')
         applyProfile(portal, 'ftw.zipexport:default')

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ tests_require = [
     'ftw.testbrowser',
     'ftw.testing<2a',
     'ftw.zipexport',
-    'plone.app.referenceablebehavior',
     'plone.app.testing',
     'plone.mocktestcase',
     'transmogrify.dexterity',


### PR DESCRIPTION
It was unnoticed that the referenceablebehaviour was still installed in tests. We want to remove that in future though.