### PR TITLE
Add changelog.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove referenceablebehavior. [busykoala]
 
 
 4.1.0 (2019-11-14)


### PR DESCRIPTION
In https://github.com/4teamwork/ftw.book/pull/115 the referenceablebehavior was removed. Here the changelog for doing that, which is missing in the Pull.