### PR TITLE
Fix CSS counters

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix CSS counters. [djowett-ftw]
 
 
 4.1.2 (2019-12-17)

--- a/ftw/book/browser/resources/theming.scss
+++ b/ftw/book/browser/resources/theming.scss
@@ -61,12 +61,7 @@ div#portal-column-one div.portletWrapper dl.portletGoToParent {
 
 /* Add chapter prefixes / numbering */
 body {
-  counter-reset: chapter;
-  counter-reset: section;
-  counter-reset: subsection;
-  counter-reset: subsubsection;
-  counter-reset: paragraph;
-  counter-reset: subparagraph;
+  counter-reset: chapter section subsection subsubsection paragraph subparagraph;
 }
 
 .toc2 {


### PR DESCRIPTION
Fixes https://github.com/4teamwork/izug.organisation/issues/1727

Lightly tested due to time, but I think this is the correct approach

> " To use CSS counter, it must first be initialized to a value with the counter-reset property."
That counter-reset also seems to need to be a direct ancestor.

Only the last `counter-reset` property was taking effect in the <body> tag.

Therefore the `section` needed an ancestor in the DOM to declare a `counter-reset` but in the above issue the resets were done by 'uncles' not direct ancestors

