### PR TITLE
Fix csv import/export

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.1.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix csv import export (there was an issue with encoding and BOM). [busykoala]
 
 
 4.1.4 (2020-01-09)

--- a/ftw/book/browser/table_export_import.py
+++ b/ftw/book/browser/table_export_import.py
@@ -1,3 +1,4 @@
+from Products.CMFDiffTool.utils import safe_utf8
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from ftw.book import _
@@ -58,7 +59,7 @@ class TableExportImport(BrowserView):
         writer.writerow(first_row)
         for row in context.getData():
             writer.writerow(dict([
-                        (col, row[col])
+                        (col, safe_utf8(row[col]))
                         for col
                         in self.active_columns]))
         file_.seek(0)
@@ -97,7 +98,8 @@ class TableExportImport(BrowserView):
             return False
         context = aq_inner(self.context)
 
-        data = stream.read()
+        # make sure the data imported is utf-8 and the BOM was removed
+        data = safe_utf8(stream.read().decode('utf-8-sig'))
         # fix bad excel carriage returns
         data = data.replace('\r\n', '\n').replace('\r', '\n')
         dialect = csv.Sniffer().sniff(data)


### PR DESCRIPTION
Close https://github.com/4teamwork/izug.organisation/issues/1821

There was a problem with the CSV import/export if they contained non-ascii characters.

For the import, I fixed removing the BOM so the URL was recognized again and also wrapped the string into safe_unicode to prevent UnicodeErrors (which would otherwise appear). For the block view itself, I also wrapped a safe_utf8 around the data loaded because the view wouldn't load otherwise.