### PR TITLE
Fix usage of AT BaseUnit in pre/post latex code fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.1.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix usage of AT BaseUnit in pre/post latex code fields. [mathias.leimgruber]
 
 
 4.1.6 (2020-01-21)

--- a/ftw/book/upgrades/20200122160516_fix_base_unit_in_i_la_te_x_code_injection_behavior/upgrade.py
+++ b/ftw/book/upgrades/20200122160516_fix_base_unit_in_i_la_te_x_code_injection_behavior/upgrade.py
@@ -1,0 +1,22 @@
+from ftw.book.behaviors.codeinjection import ILaTeXCodeInjection
+from ftw.upgrade import UpgradeStep
+from Products.CMFPlone.utils import safe_unicode
+
+
+class FixBaseUnitInILaTeXCodeInjectionBehavior(UpgradeStep):
+    """Fix BaseUnit in ILaTeXCodeInjection behavior.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        query = {'object_provides': [ILaTeXCodeInjection.__identifier__]}
+        for obj in self.objects(query, 'Fix pre post latex code field'):
+            if callable(ILaTeXCodeInjection(obj).pre_latex_code):
+                ILaTeXCodeInjection(obj).pre_latex_code = safe_unicode(
+                    ILaTeXCodeInjection(obj).pre_latex_code()
+                )
+            if callable(ILaTeXCodeInjection(obj).post_latex_code):
+                ILaTeXCodeInjection(obj).post_latex_code = safe_unicode(
+                    ILaTeXCodeInjection(obj).post_latex_code()
+                )


### PR DESCRIPTION
Probably something is missing during the uprade/migration from AT to DX.
Don't where, don't know how and why, but this should fix it. 