### PR TITLE
Check / Fix numbering for the books various views

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.1.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix chapter listing numbers in "book_reader_view" view [Nachtalb]
 
 
 4.1.7 (2020-01-22)

--- a/ftw/book/browser/resources/theming.scss
+++ b/ftw/book/browser/resources/theming.scss
@@ -132,6 +132,39 @@ body {
   }
 }
 
+.book-reader {
+  // "toc2" increments the "chapter" counter but the "chapter" couunter is not reset
+  // anywhere, thus the "chapter" counter will be increased by every chapter / sub chapter.
+  // To prevent this we reset the "chapter" counter on a known parent that every chapter has.
+  .book-reader-block {
+    counter-reset: chapter;
+  }
+
+  .toc2 {
+    counter-reset: section;
+  }
+
+  .toc3 {
+    counter-reset: subsection;
+  }
+
+  .toc4 {
+    counter-reset: subsubsection;
+  }
+
+  .toc5 {
+    counter-reset: paragraph;
+  }
+
+  .toc6 {
+    counter-reset: subparagraph;
+  }
+
+  .toc7 {
+    counter-increment: subparagraph;
+  }
+}
+
 /* Disable simplelayout design menu on chapter, since we cannot
    create a PDF with multiple columns. */
 .portaltype-chapter #simplelayout-contentmenu-design {


### PR DESCRIPTION
- [x] reader view
- [x] folder contents tab
- [x] chapters detail view
- [x] navigation
- [x] pdf

The reader view was the only one with a problem.

Book Reader `book_reader_view`
---
![image](https://user-images.githubusercontent.com/9467802/73547153-aed3d200-443e-11ea-82c4-f7ce4f9e63f1.png)
![image](https://user-images.githubusercontent.com/9467802/73547158-b004ff00-443e-11ea-88fb-0b863700c4ee.png)
