### PR TITLE
Fix the implementation of "ftw.simplelayout".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.1.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix integration of ftw.simplelayout. [mbaechtold]
 
 
 4.1.8 (2020-02-11)

--- a/ftw/book/profiles/default/types/ftw.book.Book.xml
+++ b/ftw/book/profiles/default/types/ftw.book.Book.xml
@@ -19,6 +19,7 @@
     <property name="add_permission">ftw.book.AddBook</property>
 
     <property name="behaviors">
+        <element value="ftw.simplelayout.interfaces.ISimplelayout" />
         <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="plone.app.dexterity.behaviors.metadata.IBasic" />

--- a/ftw/book/profiles/default/types/ftw.book.Chapter.xml
+++ b/ftw/book/profiles/default/types/ftw.book.Chapter.xml
@@ -23,7 +23,6 @@
     <property name="add_permission">ftw.book.AddChapter</property>
 
     <property name="behaviors">
-        <element value="ftw.simplelayout.interfaces.ISimplelayout" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
         <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
         <element value="plone.app.content.interfaces.INameFromTitle" />

--- a/ftw/book/upgrades/20200324122934_fix_simplelayout/types/ftw.book.Book.xml
+++ b/ftw/book/upgrades/20200324122934_fix_simplelayout/types/ftw.book.Book.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ftw.book.Book">
+
+    <property name="behaviors" purge="False">
+        <element value="ftw.simplelayout.interfaces.ISimplelayout" />
+    </property>
+
+</object>

--- a/ftw/book/upgrades/20200324122934_fix_simplelayout/types/ftw.book.Chapter.xml
+++ b/ftw/book/upgrades/20200324122934_fix_simplelayout/types/ftw.book.Chapter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ftw.book.Chapter">
+
+    <property name="behaviors" purge="False">
+        <element value="ftw.simplelayout.interfaces.ISimplelayout" remove="True" />
+    </property>
+
+</object>


### PR DESCRIPTION
Simplelayout blocks (like the chapter) do not need to have the behavior "ftw.simplelayout.interfaces.ISimplelayout".

The book on the other hand needs to have the behaviour "ftw.simplelayout.interfaces.ISimplelayout". Otherwise removing a deleted block from the trash fails horribly with an exception in "ftw.simplelayout".