### PR TITLE
Fix error on broken links during read view render

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.1.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix error on broken links during read view render [Nachtalb]
 
 
 4.1.9 (2020-03-24)

--- a/ftw/book/browser/reader/renderer.py
+++ b/ftw/book/browser/reader/renderer.py
@@ -80,7 +80,7 @@ class DefaultBlockRenderer(BaseBookReaderRenderer):
             portal_catalog = api.portal.get_tool('portal_catalog')
             obj = portal_catalog.unrestrictedSearchResults(UID=parts[-1])
 
-            if obj is not None:
+            if obj:
                 url = obj[0].getURL()
         return url
 


### PR DESCRIPTION
I don't know why we only tested for `None`. Maybe in some Plone versions, we get `None` but in Plone 5.1 we get `[]`, so it thought we actually did find an object. Luckily both are falsy so we can just check for the falseness. 