### PR TITLE
Add View permission check for `in_toc` method.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.1.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add View permission check for `in_toc` method. [mathias.leimgruber]
 
 
 4.1.10 (2021-04-01)

--- a/ftw/book/testing.py
+++ b/ftw/book/testing.py
@@ -139,6 +139,13 @@ class BookLayer(PloneSandboxLayer):
                    .titled(u'Empty')
                    .having(description=u'This chapter should be empty.'))
 
+            no_view_permission = create(Builder('chapter').within(book)
+                                        .titled(u'No Permission')
+                                        .having(description=u'This chapter has no view permission.'))
+            no_view_permission.manage_permission('View', roles=[])
+            no_view_permission.reindexObject()
+            transaction.commit()
+
         return book
 
     def create_default_layout_book(self):
@@ -218,7 +225,7 @@ class LanguageSetter(object):
             self._set_preferred_language(default)
             registry = getUtility(IRegistry)
             language_settings = registry.forInterface(
-                    ILanguageSchema, prefix='plone')
+                ILanguageSchema, prefix='plone')
             language_settings.use_content_negotiation = True
         else:
             self.ltool = api.portal.get().portal_languages

--- a/ftw/book/tests/test_toc.py
+++ b/ftw/book/tests/test_toc.py
@@ -21,6 +21,7 @@ class TestTableOfContents(FunctionalTestCase):
             'historical-background/china/first-things-first',
             'historical-background/china/important-documents',
             LOREM_ITEM,
+            'no-permission'
         ))
 
     def test_html_heading(self):
@@ -39,6 +40,7 @@ class TestTableOfContents(FunctionalTestCase):
                 '<h4 class="toc4">First things first</h4>',
                 '<h4 class="toc4">Important Documents</h4>',
                 '<h5 class="no-toc">Einfache Webseite</h5>',
+                '<h2 class="no-toc">No Permission</h2>',
             ],
             map(toc.html_heading, self.sample_objects()))
 
@@ -98,6 +100,7 @@ class TestTableOfContents(FunctionalTestCase):
                 'First things first': True,
                 'Important Documents': True,
                 'Einfache Webseite': False,
+                'No Permission': False,
             },
             {
                 obj.Title(): toc.in_toc(obj)
@@ -120,6 +123,7 @@ class TestTableOfContents(FunctionalTestCase):
                 'First things first': True,
                 'Important Documents': True,
                 'Einfache Webseite': True,
+                'No Permission': True,
             },
             {
                 obj.Title(): toc.in_book(obj)
@@ -142,6 +146,7 @@ class TestTableOfContents(FunctionalTestCase):
                 'First things first': True,
                 'Important Documents': True,
                 'Einfache Webseite': True,
+                'No Permission': True,
             },
             {
                 obj.Title(): toc.visible(obj)
@@ -164,6 +169,7 @@ class TestTableOfContents(FunctionalTestCase):
                 'First things first': 4,
                 'Important Documents': 4,
                 'Einfache Webseite': 5,
+                'No Permission': 2,
             },
             {
                 obj.Title(): toc.level(obj)
@@ -186,6 +192,7 @@ class TestTableOfContents(FunctionalTestCase):
                 'First things first': 1,
                 'Important Documents': 2,
                 'Einfache Webseite': None,
+                'No Permission': None,  # Uses in_toc, which has a permission check
             },
             {
                 obj.Title(): toc.index(obj)
@@ -208,6 +215,7 @@ class TestTableOfContents(FunctionalTestCase):
                 'First things first': '2.1.1',
                 'Important Documents': '2.1.2',
                 'Einfache Webseite': None,
+                'No Permission': None,
             },
             {
                 obj.Title(): toc.number(obj)

--- a/ftw/book/toc.py
+++ b/ftw/book/toc.py
@@ -4,6 +4,7 @@ from Acquisition import aq_parent
 from ftw.book.behaviors.toc import IHideTitleFromTOC
 from ftw.book.behaviors.toc import IShowInToc
 from ftw.book.interfaces import IBook
+from plone import api
 import cgi
 
 
@@ -75,6 +76,9 @@ class TableOfContents(object):
     def in_toc(self, context):
         """Returns `True` if the object is shown in the table of contents.
         """
+        if not api.user.has_permission('View', obj=context):
+            return False
+
         if not IShowInToc.providedBy(context):
             return False
 


### PR DESCRIPTION
The toc builder did no respect the view permission of an object. Which resulted in a wrong numbering on the chapter view itself. 